### PR TITLE
Raspbian Stretch support

### DIFF
--- a/sysroot/Dockerfile_raspbian_arm
+++ b/sysroot/Dockerfile_raspbian_arm
@@ -1,0 +1,21 @@
+# Raspbian Stretch Lite
+FROM raspbian/stretch
+
+ENV LANG en_US.UTF-8
+ENV LC_ALL C.UTF-8
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update
+
+# install Fast-RTPS dependencies
+RUN apt install --no-install-recommends -y libasio-dev libtinyxml2-dev
+
+# dependencies resolved by rosdep
+RUN apt install --no-install-recommends -y libeigen3-dev libtinyxml2-dev python3-yaml libcurl4-openssl-dev curl pkg-config libcppunit-dev libpcre3-dev cmake clang-format libyaml-dev python3-flake8 pyflakes3 cppcheck libboost-all-dev liblog4cxx-dev python3-pkg-resources libxml2-utils libopencv-dev libogg-dev libtinyxml-dev libconsole-bridge-dev uncrustify libtheora-dev python3-pytest libpoco-dev pydocstyle zlib1g-dev python3-empy python3-setuptools python3-numpy python3-pep8
+
+# additional python packages via pip
+RUN apt install --no-install-recommends -y python3-pip
+# error: invalid command 'bdist_wheel'
+RUN pip3 install wheel
+# install python3-lark-parser, python3-opencv
+RUN pip3 install lark-parser opencv-python


### PR DESCRIPTION
This PR adds a docker file for Raspbian.

At the moment, I cannot successfully build ROS2 with this image since the library `libPocoFoundation.so.50`, which is installed by `poco_vendor`, cannot be found.
This issue does not appear on Ubuntu, since this library is provided by package `libpocofoundation50`.

# Build

The instructions are adapted from https://index.ros.org/doc/ros2/Tutorials/Cross-compilation/.

1. create rootfs:
```bash
docker build -t raspbian_ros2:latest -f ros2_ws/src/ros2/cross_compile/sysroot/Dockerfile_raspbian_arm .
```
```bash
docker create --name arm_sysroot raspbian_ros2
docker container export -o sysroot_docker.tar arm_sysroot
docker rm arm_sysroot
mkdir sysroot_docker
tar -C sysroot_docker -xf sysroot_docker.tar lib usr opt etc
```

2. build:
```bash
export TARGET_ARCH=armhf
export TARGET_TRIPLE=arm-linux-gnueabihf
export CC=/usr/bin/$TARGET_TRIPLE-gcc
export CXX=/usr/bin/$TARGET_TRIPLE-g++
export CROSS_COMPILE=/usr/bin/$TARGET_TRIPLE-
export SYSROOT=~/ros2_rpi/sysroot_docker
export ROS2_INSTALL_PATH=~/ros2_rpi/ros2_ws/install
export PYTHON_SOABI=cpython-36m-$TARGET_TRIPLE
```

```bash
colcon build --merge-install \
    --cmake-force-configure \
    --cmake-args \
        -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
        -DCMAKE_TOOLCHAIN_FILE="$(pwd)/src/ros2/cross_compile/cmake-toolchains/generic_linux.cmake"
```

# Unresolved issues

The build fails (at package `test_msgs`) because the poco library cannot be found:
```
 warning: libPocoFoundation.so.50, needed by ~/ros2_rpi/ros2_ws/install/lib/librosidl_typesupport_cpp.so, not found (try using -rpath or -rpath-link)
```
even though it's located in the `install` space:
```
file install/lib/libPocoFoundation.so.50
install/lib/libPocoFoundation.so.50: ELF 32-bit LSB shared object, ARM, EABI5 version 1 (GNU/Linux), dynamically linked, BuildID[sha1]=b79d43aa8df0349394cbf54c0b2fd18bdaf0af0a, with debug_info, not stripped
```
The issue still persists after setting the rpath via ``-DCMAKE_BUILD_RPATH="`pwd`/install/lib/"``.

Did anyone encounter the same issue?