### PR TITLE
Remove non-portable use of USER environment variable

### DIFF
--- a/cross_compile/sysroot_compiler.py
+++ b/cross_compile/sysroot_compiler.py
@@ -14,6 +14,7 @@
 
 """Contains all classes used by the sysroot_compiler.py script."""
 
+import getpass
 import logging
 import os
 from pathlib import Path
@@ -116,7 +117,7 @@ class Platform:
 
     def get_workspace_image_tag(self) -> str:
         """Generate docker image name and tag."""
-        return os.getenv('USER') + '/' + str(self) + ':latest'
+        return getpass.getuser() + '/' + str(self) + ':latest'
 
 
 class DockerConfig:

--- a/test/test_sysroot_compiler.py
+++ b/test/test_sysroot_compiler.py
@@ -15,7 +15,7 @@
 
 """Unit tests for the `create_cc_sysroot.py` script."""
 
-import os
+import getpass
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Tuple
@@ -74,7 +74,7 @@ def setup_mock_sysroot(path: Path) -> Tuple[Path, Path]:
 def test_get_workspace_image_tag(platform_config):
     """Make sure the image tag is created correctly."""
     image_tag = platform_config.get_workspace_image_tag()
-    test_tag = '{}/{}:latest'.format(os.getenv('USER'), str(platform_config))
+    test_tag = '{}/{}:latest'.format(getpass.getuser(), str(platform_config))
     assert isinstance(image_tag, str)
     assert image_tag == test_tag
 


### PR DESCRIPTION
USER env var doesn't port to all build environments (e.g. DOCKER) and doesn't necessarily work on Windows. `getpass` module provides the portable tool

See http://build.ros2.org/job/Ddev__cross_compile__ubuntu_bionic_amd64/1/testReport/junit/cross_compile.test/test_sysroot_compiler/test_get_workspace_image_tag/