### PR TITLE
Fix: Wrong link to `mixins/index.yaml` in Dockerfile_workspace

### DIFF
--- a/cross_compile/Dockerfile_workspace
+++ b/cross_compile/Dockerfile_workspace
@@ -95,7 +95,7 @@ RUN rosdep install --from-paths src /opt/ros/${ROS_DISTRO}/share \
         urdfdom_headers"
 
 RUN colcon mixin add cc_mixin \
-    https://raw.githubusercontent.com/ros-tooling/cross_compile/cc-sysroot-creator/mixins/index.yaml && \
+    https://raw.githubusercontent.com/ros-tooling/cross_compile/master/mixins/index.yaml && \
     colcon mixin update cc_mixin
 RUN colcon build --mixin ${TARGET_ARCH}-docker
 


### PR DESCRIPTION
I was trying to cross compile ROS2 to armhf architecture and discovered that link to `mixins/index.yaml` is broken. This PR fix it, but shouldn't sysroot_compiler use local file instead?

---
Outside of this, there is no remark in README that `Dockerfile_workspace` should be putted into `sysroot` folder. If this is correct, I guess it should be stated here: https://github.com/ros-tooling/cross_compile#3-run-the-cross-compilation-script . At least I couldn't get it to work until I put it there.

Connected to this - maybe it should be stated explicitely that argument `--sysroot-path` must be absolute path; that took some time to realise why `sysroot/Dockerfile_workspace` was not found.