### PR TITLE
Move `apt install symlinks` command from end of `Dockerfile_workspace`

### DIFF
--- a/cross_compile/Dockerfile_workspace
+++ b/cross_compile/Dockerfile_workspace
@@ -47,6 +47,8 @@ RUN apt update && apt install -y \
     python-rosdep \
     wget
 
+RUN apt install -y symlinks
+
 # Install some pip packages needed for testing
 RUN python3 -m pip install -U \
     argcomplete \
@@ -107,5 +109,4 @@ RUN mkdir -p /root_path/usr \
  && cp -r /usr/lib/gcc/${TARGET_TRIPLE}/7/* /root_path/usr/lib
 
 WORKDIR /
-RUN apt install -y symlinks
 RUN symlinks -rc .

--- a/cross_compile/Dockerfile_workspace
+++ b/cross_compile/Dockerfile_workspace
@@ -30,7 +30,7 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Add the ros2 apt repo
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
     curl \
     gnupg2 \
     lsb-release
@@ -39,7 +39,7 @@ RUN sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb
     > /etc/apt/sources.list.d/ros2-latest.list'
 
 # ROS2 dependencies
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
     build-essential \
     cmake \
     git \
@@ -47,7 +47,7 @@ RUN apt update && apt install -y \
     python-rosdep \
     wget
 
-RUN apt install -y symlinks
+RUN apt-get install -y symlinks
 
 # Install some pip packages needed for testing
 RUN python3 -m pip install -U \
@@ -72,7 +72,7 @@ RUN python3 -m pip install -U \
     vcstool
 
 # Install Fast-RTPS dependencies
-RUN apt install --no-install-recommends -y \
+RUN apt-get install --no-install-recommends -y \
     libasio-dev \
     libtinyxml2-dev
 


### PR DESCRIPTION
Yesterday evening I set up everything and leave `cross_compile` to build all ROS repos at night. But due to faulty internet connection at night at our office, build overall was failed with `Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/universe/s/symlinks/symlinks_1.4-3build1_armhf.deb`.

So this PR removes dependency on internet connection after `colcon build` start.
As far as I can see, `apt install symlinks` command from the end of Dockerfile_workspace could be moved to the beginning without problems. I consider merge it into any other `apt install` command, but didn't want to break considerations behind each `apt install` section.

Meanwhile, is there any actual reasons of using `apt` _and_ `apt-get`? I see both in Dockerfile_workspace.