### PR TITLE
Move symlinks install and convert apt to apt-get

### DIFF
--- a/cross_compile/Dockerfile_workspace
+++ b/cross_compile/Dockerfile_workspace
@@ -30,7 +30,7 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Add the ros2 apt repo
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
     curl \
     gnupg2 \
     lsb-release
@@ -39,13 +39,15 @@ RUN sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb
     > /etc/apt/sources.list.d/ros2-latest.list'
 
 # ROS2 dependencies
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
     build-essential \
     cmake \
     git \
     python3-pip \
     python-rosdep \
     wget
+
+RUN apt-get install -y symlinks
 
 # Install some pip packages needed for testing
 RUN python3 -m pip install -U \
@@ -70,7 +72,7 @@ RUN python3 -m pip install -U \
     vcstool
 
 # Install Fast-RTPS dependencies
-RUN apt install --no-install-recommends -y \
+RUN apt-get install --no-install-recommends -y \
     libasio-dev \
     libtinyxml2-dev
 
@@ -107,5 +109,4 @@ RUN mkdir -p /root_path/usr \
  && cp -r /usr/lib/gcc/${TARGET_TRIPLE}/7/* /root_path/usr/lib
 
 WORKDIR /
-RUN apt install -y symlinks
 RUN symlinks -rc .


### PR DESCRIPTION
Same changes as #40 moved to local branch due to status checks failing.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>