### PR TITLE
[WIP] Use git info to automatically determine the version number

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
   <license>Apache 2.0</license>
 
   <depend>python3-docker</depend>
+  <depend>python3-setuptools-scm</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 script-dir=$base/lib/cross_compile
 [install]
 install-scripts=$base/lib/cross_compile
+[options]
+setup_requires =
+  setuptools_scm


### PR DESCRIPTION
This introduces a dependency on setuptools-scm which expends setuptools
to automatically determine the package version number based on git
information.

This PR should not be merged until ros/rosdistro#22887 is merged as it
declares the associated rosdep entry for setuptools-scm.