### PR TITLE
Automatically upload new releases to PyPI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,19 @@ jobs:
       with:
         name: colcon-logs-${{ matrix.os }}
         path: ros2_ws/log
+    # Upload the package to the PyPI test repository.
+    # This will silently fail if a package with this version number already
+    # exists.
+    - uses: ros-tooling/action-pypi@0.0.1
+      # As the package is platform-independent, only trigger this step on Linux
+      # and only on push.
+      # This action should never happen on pull-request, as it would lead us
+      # to upload the package in its initial state, before review.
+      # The final state of the pull request would then never be uploaded, as
+      # we cannot overwrite packages.
+      if: matrix.os == 'ubuntu-18.04' && github.event_name == 'push'
+      with:
+        package-directory: ros2_ws/src/cross_compile
+        username: ${{ secrets.PYPI_USERNAME }}
+        password: ${{ secrets.PYPI_PASSWORD }}
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This uploads the new releases of this package to the test PyPI
repository. We will switch the main PyPI repo, once we validate this
workflow works properly.