### PR TITLE
Make the documentation for the sysroot argument correct 

### DIFF
--- a/cross_compile/ros2_cross_compile.py
+++ b/cross_compile/ros2_cross_compile.py
@@ -18,6 +18,7 @@
 
 import argparse
 import logging
+import os
 from string import Template
 import sys
 
@@ -113,9 +114,8 @@ def create_arg_parser():
     parser.add_argument(
         '--sysroot-path',
         required=False,
-        default=None,
+        default=os.getcwd(),
         type=str,
-        nargs='?',
         help=_SYSROOT_PATH)
     return parser
 


### PR DESCRIPTION
Make the documentation for the sysroot argument correct by defaulting to the current working directory. 

Before this PR, if you didn't pass the argument, an error would be raised by the SysrootCompiler verifying its argument.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>