### PR TITLE
Enable en_US.UTF-8 locale in locale-gen

### DIFF
--- a/cross_compile/Dockerfile_ros2
+++ b/cross_compile/Dockerfile_ros2
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Set locale
-RUN locale-gen en_US en_US.UTF-8 && \
+RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && \
+    locale-gen && \
     update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
Enable `en_US.UTF-8` for `locale-gen` before running `locale-gen`