### PR TITLE
Allow for finding ROS packages in armhf builds

### DIFF
--- a/cross_compile/Dockerfile_ros2
+++ b/cross_compile/Dockerfile_ros2
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y \
         lsb-release \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" \
+RUN sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" \
     > /etc/apt/sources.list.d/ros2-latest.list'
 
 # ROS2 dependencies


### PR DESCRIPTION
The line adding the ROS apt sources explicitly specified architectures. Since we are working in an emulated environment, the only architecture we need is the "native"/emulated one, so we don't have to specify. 

This fixes the use case for armhf builds that have ROS rosdeps, because the armhf sources were not being added.