### PR TITLE
Don't pass argparse.Namespace out of the argument parsing context 

### DIFF
--- a/cross_compile/ros2_cross_compile.py
+++ b/cross_compile/ros2_cross_compile.py
@@ -110,8 +110,11 @@ def main():
     # Configuration
     parser = create_arg_parser()
     args = parser.parse_args()
-    platform = Platform(args)
-    docker_args = DockerConfig(args)
+    platform = Platform(
+        args.arch, args.os, args.distro, args.rmw)
+    docker_args = DockerConfig(
+        args.arch, args.os, args.sysroot_base_image,
+        args.docker_network_mode, args.sysroot_nocache)
 
     # Main pipeline
     sysroot_create = SysrootCompiler(cc_root_dir=args.sysroot_path,

--- a/cross_compile/sysroot_compiler.py
+++ b/cross_compile/sysroot_compiler.py
@@ -71,12 +71,12 @@ class Platform:
     4. RMW implementation used
     """
 
-    def __init__(self, args):
+    def __init__(self, arch: str, os: str, distro: str, rmw: str):
         """Initialize platform parameters."""
-        self.arch = args.arch
-        self.os = args.os
-        self.distro = args.distro
-        self.rmw = args.rmw
+        self.arch = arch
+        self.os = os
+        self.distro = distro
+        self.rmw = rmw
 
         if self.arch == 'armhf':
             self.cc_toolchain = 'arm-linux-gnueabihf'
@@ -109,16 +109,19 @@ class DockerConfig:
         ('aarch64', 'debian'): 'arm64v8/debian:latest',
     }  # type: Dict[tuple, str]
 
-    def __init__(self, args):
+    def __init__(
+        self, arch: str, os: str, sysroot_base_image: str,
+        docker_network_mode: str, sysroot_nocache: bool
+    ):
         """Initialize docker configuration."""
-        if args.sysroot_base_image is None:
+        if sysroot_base_image is None:
             self.base_image = \
-                self._default_docker_base_image[args.arch, args.os]
+                self._default_docker_base_image[arch, os]
         else:
-            self.base_image = args.sysroot_base_image
+            self.base_image = sysroot_base_image
 
-        self.network_mode = args.docker_network_mode
-        self.nocache = args.sysroot_nocache
+        self.network_mode = docker_network_mode
+        self.nocache = sysroot_nocache
 
     def __str__(self):
         """Return string representation of docker build parameters."""

--- a/test/test_sysroot_compiler.py
+++ b/test/test_sysroot_compiler.py
@@ -17,7 +17,6 @@
 
 import getpass
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Tuple
 
 from cross_compile.sysroot_compiler import DockerConfig
@@ -29,31 +28,29 @@ from cross_compile.sysroot_compiler import SysrootCompiler
 import pytest
 
 
-def _default_args() -> SimpleNamespace:
-    # TODO: Change base image to dockerhub repo image once we have access.
-
-    args: SimpleNamespace = SimpleNamespace()
-    args.arch = 'aarch64'
-    args.os = 'ubuntu'
-    args.distro = 'dashing'
-    args.rmw = 'fastrtps'
-    args.sysroot_base_image = (
-        '035662560449.dkr.ecr.us-east-2.amazonaws.com/cc-tool:'
-        'aarch64-bionic-dashing-fastrtps-prebuilt')
-    args.docker_network_mode = 'host'
-    args.sysroot_nocache = 'False'
-
-    return args
+def _default_docker_kwargs() -> dict:
+    return {
+        'arch': 'aarch64',
+        'os': 'ubuntu',
+        'sysroot_base_image': '035662560449.dkr.ecr.us-east-2.amazonaws.com/cc-tool:'
+                              'aarch64-bionic-dashing-fastrtps-prebuilt',
+        'docker_network_mode': 'host',
+        'sysroot_nocache': False,
+    }
 
 
 @pytest.fixture
 def platform_config() -> Platform:
-    return Platform(_default_args())
+    return Platform(
+        arch='aarch64',
+        os='ubuntu',
+        distro='dashing',
+        rmw='fastrtps')
 
 
 @pytest.fixture
 def docker_config() -> DockerConfig:
-    return DockerConfig(_default_args())
+    return DockerConfig(**_default_docker_kwargs())
 
 
 def setup_mock_sysroot(path: Path) -> Tuple[Path, Path]:
@@ -81,13 +78,14 @@ def test_get_workspace_image_tag(platform_config):
 
 def test_docker_config_args(docker_config):
     """Make sure the Docker configuration is setup correctly."""
-    args = _default_args()
+    args = _default_docker_kwargs()
     test_config_string = (
         'Base Image: {}\n'
         'Network Mode: {}\n'
-        'Caching: {}').format(
-        args.sysroot_base_image, args.docker_network_mode,
-        args.sysroot_nocache)
+        'Caching: {}'
+    ).format(
+        args['sysroot_base_image'], args['docker_network_mode'], args['sysroot_nocache']
+    )
     config_string = str(docker_config)
     assert isinstance(config_string, str)
     assert config_string == test_config_string


### PR DESCRIPTION
Be explicit about required arguments passed to constructors and their types.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>