### PR TITLE
Export the cross compiled install dir to the correct location

### DIFF
--- a/cross_compile/Dockerfile_ros2
+++ b/cross_compile/Dockerfile_ros2
@@ -107,4 +107,5 @@ RUN colcon mixin add cc_mixin \
     https://raw.githubusercontent.com/ros-tooling/cross_compile/master/mixins/index.yaml && \
     colcon mixin update cc_mixin
 RUN mkdir -p /opt/ros/${ROS_DISTRO} && touch /opt/ros/${ROS_DISTRO}/setup.sh
-RUN . /opt/ros/${ROS_DISTRO}/setup.sh && colcon build --mixin ${TARGET_ARCH}-docker
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
+    colcon build --mixin ${TARGET_ARCH}-docker --install-base install_${TARGET_ARCH}


### PR DESCRIPTION
The install dir was not being output to the correct place. The desired location was next to the sources, like in a regular colcon workspace.

Add an architecture-specific suffix to the export install directory so that multiple cross-compiles can be done.

Add these checks to the e2e test to make sure this keeps working.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>