### PR TITLE
Add ROS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Please follow those instructions if you plan to contribute to this repository.
 * Checkout the source code and compile it as follows
 
 ```bash
-mkdir -p ~/ros2_cross_compile_ws/src
-cd ros2_cross_compile_ws
+mkdir -p ~/ros_cross_compile_ws/src
+cd ros_cross_compile_ws
 
 # Use vcs to clone all required repositories
 curl -fsSL https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos | vcs import src/
@@ -84,7 +84,7 @@ The following instructions explain how to create a `sysroot` directory.
 #### Create the directory structure
 ```bash
 mkdir -p sysroot/qemu-user-static
-mkdir -p sysroot/ros2_ws/src
+mkdir -p sysroot/ros_ws/src
 ```
 
 #### Copy the QEMU Binaries
@@ -93,15 +93,14 @@ mkdir -p sysroot/ros2_ws/src
 cp /usr/bin/qemu-*-static sysroot/qemu-user-static/
 ```
 
-#### Prepare ros2_ws
 
+#### 3. Prepare ros_ws
+Use [ROS](http://wiki.ros.org/ROS/Installation) or [ROS 2](https://index.ros.org/doc/ros2/Installation/) source installation guide to get the ROS repositories needed to cross compile.
+
+Once you have the desired sources, copy them in the `sysroot` to use with the tool. 
 ```bash
-# Copy in your ros2_ws
-cp -r <full_path_to_your_ros_ws>/src sysroot/ros2_ws/src
-
-# Use vcs to checkout the required ROS2 version.
-# Substitute `master` for `release-latest` or a specific release like `dashing`.
-curl -fsSL https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos | vcs import src/
+# Copy ros sources into the sysroot directory
+cp -r <full_path_to_your_ros_ws>/src sysroot/ros_ws/src
 ```
 
 #### Run the cross compilation script
@@ -112,9 +111,9 @@ In the end your `sysroot` directory should look like this:
 sysroot/
  +-- qemu-user-static/
  |   +-- qemu-*-static
- +-- ros2_ws/
+ +-- ros_ws/
      +-- src/
-          |-- (ros2 packages)
+          |-- (ros packages)
           +-- ...
 ```
 

--- a/cross_compile/Dockerfile_ros
+++ b/cross_compile/Dockerfile_ros
@@ -1,17 +1,20 @@
-# This dockerfile takes ROS2 source packages from ${ROS2_WORKSPACE}/ros2_ws/src
+# This dockerfile takes ROS 1 or 2 source packages from ${ROS_WORKSPACE}/ros_ws/src
 # and builds them for the specified target platform.
-# It uses qemu user-mode static emulation libraries from ${ROS2_WORKSPACE}/qemu-user-static/
+# It uses qemu user-mode static emulation libraries from ${ROS_WORKSPACE}/qemu-user-static/
 # to emulate the target platform.
 
-# Assumptions: ros2_ws/src and qemu-user-static directories are present in  ${ROS2_WORKSPACE}.
+# Assumptions: ros_ws/src and qemu-user-static directories are present in ${ROS_WORKSPACE}.
 
-ARG ROS2_BASE_IMG
-FROM ${ROS2_BASE_IMG}
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
-ARG ROS2_WORKSPACE
+ARG ROS_WORKSPACE
+ARG ROS_VERSION
 ARG ROS_DISTRO
 ARG TARGET_TRIPLE
 ARG TARGET_ARCH
+
+SHELL ["/bin/bash", "-c"]
 
 COPY qemu-user-static/ /usr/bin/
 
@@ -31,32 +34,38 @@ RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && \
 ENV LANG en_US.UTF-8
 ENV LC_ALL C.UTF-8
 
-# Add the ros2 apt repo
+# Add the ros apt repo
 RUN apt-get update && apt-get install -y \
         curl \
         gnupg2 \
         lsb-release \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
-RUN sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" \
-    > /etc/apt/sources.list.d/ros2-latest.list'
 
-# ROS2 dependencies
+RUN if [[ "${ROS_VERSION}" == "ROS2" ]]; then \
+    echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" \
+    > /etc/apt/sources.list.d/ros2-latest.list; \
+  else \
+    echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" \
+    > /etc/apt/sources.list.d/ros-latest.list; \
+  fi
+
+# ROS dependencies
 RUN apt-get update && apt-get install -y \
       build-essential \
       cmake \
       git \
+      python3-colcon-common-extensions \
+      python3-colcon-mixin \
       python3-pip \
       python-rosdep \
       wget \
-      symlinks \
     && rm -rf /var/lib/apt/lists/*
 
-# Install some pip packages needed for testing
-RUN python3 -m pip install -U \
+# Install some pip packages needed for testing ROS 2
+RUN if [[ "${ROS_VERSION}" == "ROS2" ]]; then \
+    python3 -m pip install -U \
     argcomplete \
-    colcon-common-extensions \
-    colcon-mixin \
     flake8 \
     flake8-blind-except \
     flake8-builtins \
@@ -72,13 +81,16 @@ RUN python3 -m pip install -U \
     pytest-cov \
     pytest-runner \
     setuptools \
-    vcstool
+    vcstool; \
+  fi
 
-# Install Fast-RTPS dependencies
-RUN apt-get update && apt-get install --no-install-recommends -y \
+# Install Fast-RTPS dependencies for ROS 2
+RUN if [[ "${ROS_VERSION}" == "ROS2" ]]; then \
+    apt-get update && apt-get install --no-install-recommends -y \
         libasio-dev \
         libtinyxml2-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*; \
+  fi
 
 # Run arbitrary user setup
 COPY user-custom-setup .
@@ -86,21 +98,31 @@ RUN chmod +x ./user-custom-setup && \
     ./user-custom-setup && \
     rm -rf /var/lib/apt/lists/*
 
-# Setup ROS2 workspace
-COPY ${ROS2_WORKSPACE}/src /ros2_ws/src
-WORKDIR /ros2_ws
+# Setup ROS workspace
+COPY ${ROS_WORKSPACE}/src /ros_ws/src
+WORKDIR /ros_ws
 
-# Run rosdep to get dependencies for the copied-in ROS2 workspace
+# Run rosdep to get dependencies for the copied-in ROS workspace
 ENV ROSDEP_SKIP_KEYS="console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
-RUN rm -f /etc/ros/rosdep/sources.list.d/20-default.list    # In case of cached image.
+
+RUN rm -f /etc/ros/rosdep/sources.list.d/20-default.list
 RUN rosdep init
-RUN rosdep update && \
+RUN rosdep update
+
+RUN if [[ "${ROS_VERSION}" == "ROS2" ]]; then \
     apt-get update && \
-    rosdep install --from-paths src \
-        --ignore-src \
-        --rosdistro ${ROS_DISTRO} -y \
-        --skip-keys "${ROSDEP_SKIP_KEYS}" \
-    && rm -rf /var/lib/apt/lists/*
+        rosdep install --from-paths src \
+            --ignore-src \
+            --rosdistro ${ROS_DISTRO} -y \
+            --skip-keys "${ROSDEP_SKIP_KEYS}" \
+        && rm -rf /var/lib/apt/lists/*; \
+  else \
+    apt-get update && \
+        rosdep install --from-paths src \
+            --ignore-src \
+            --rosdistro ${ROS_DISTRO} -y \
+        && rm -rf /var/lib/apt/lists/*; \
+  fi
 
 # Set up and run the build for the workspace (this will be removed from here when we get to host-native cross-compiling)
 RUN colcon mixin add cc_mixin \

--- a/cross_compile/Dockerfile_ros
+++ b/cross_compile/Dockerfile_ros
@@ -42,13 +42,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
 
-RUN if [[ "${ROS_VERSION}" == "ROS2" ]]; then \
-    echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" \
-    > /etc/apt/sources.list.d/ros2-latest.list; \
-  else \
-    echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" \
-    > /etc/apt/sources.list.d/ros-latest.list; \
-  fi
+RUN echo "deb http://packages.ros.org/${ROS_VERSION}/ubuntu `lsb_release -cs` main" \
+    > /etc/apt/sources.list.d/${ROS_VERSION}-latest.list
 
 # ROS dependencies
 RUN apt-get update && apt-get install -y \
@@ -63,7 +58,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install some pip packages needed for testing ROS 2
-RUN if [[ "${ROS_VERSION}" == "ROS2" ]]; then \
+RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
     python3 -m pip install -U \
     argcomplete \
     flake8 \
@@ -85,7 +80,7 @@ RUN if [[ "${ROS_VERSION}" == "ROS2" ]]; then \
   fi
 
 # Install Fast-RTPS dependencies for ROS 2
-RUN if [[ "${ROS_VERSION}" == "ROS2" ]]; then \
+RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
     apt-get update && apt-get install --no-install-recommends -y \
         libasio-dev \
         libtinyxml2-dev \
@@ -109,20 +104,12 @@ RUN rm -f /etc/ros/rosdep/sources.list.d/20-default.list
 RUN rosdep init
 RUN rosdep update
 
-RUN if [[ "${ROS_VERSION}" == "ROS2" ]]; then \
-    apt-get update && \
+RUN apt-get update && \
         rosdep install --from-paths src \
             --ignore-src \
             --rosdistro ${ROS_DISTRO} -y \
             --skip-keys "${ROSDEP_SKIP_KEYS}" \
-        && rm -rf /var/lib/apt/lists/*; \
-  else \
-    apt-get update && \
-        rosdep install --from-paths src \
-            --ignore-src \
-            --rosdistro ${ROS_DISTRO} -y \
-        && rm -rf /var/lib/apt/lists/*; \
-  fi
+        && rm -rf /var/lib/apt/lists/*
 
 # Set up and run the build for the workspace (this will be removed from here when we get to host-native cross-compiling)
 RUN colcon mixin add cc_mixin \

--- a/cross_compile/Dockerfile_ros
+++ b/cross_compile/Dockerfile_ros
@@ -57,6 +57,9 @@ RUN apt-get update && apt-get install -y \
       wget \
     && rm -rf /var/lib/apt/lists/*
 
+RUN python3 -m pip install -U \
+    setuptools
+
 # Install some pip packages needed for testing ROS 2
 RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
     python3 -m pip install -U \
@@ -75,7 +78,6 @@ RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
     pytest \
     pytest-cov \
     pytest-runner \
-    setuptools \
     vcstool; \
   fi
 
@@ -102,14 +104,13 @@ ENV ROSDEP_SKIP_KEYS="console_bridge fastcdr fastrtps libopensplice67 libopenspl
 
 RUN rm -f /etc/ros/rosdep/sources.list.d/20-default.list
 RUN rosdep init
-RUN rosdep update
-
-RUN apt-get update && \
-        rosdep install --from-paths src \
-            --ignore-src \
-            --rosdistro ${ROS_DISTRO} -y \
-            --skip-keys "${ROSDEP_SKIP_KEYS}" \
-        && rm -rf /var/lib/apt/lists/*
+RUN rosdep update && \
+    apt-get update && \
+    rosdep install --from-paths src \
+        --ignore-src \
+        --rosdistro ${ROS_DISTRO} -y \
+        --skip-keys "${ROSDEP_SKIP_KEYS}" \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set up and run the build for the workspace (this will be removed from here when we get to host-native cross-compiling)
 RUN colcon mixin add cc_mixin \

--- a/cross_compile/ros2_cross_compile.py
+++ b/cross_compile/ros2_cross_compile.py
@@ -50,7 +50,7 @@ def create_arg_parser():
         required=False,
         type=str,
         default='dashing',
-        choices=['dashing', 'eloquent', 'kinetic', 'melodic'],
+        choices=Platform.SUPPORTED_ROS_DISTROS + Platform.SUPPORTED_ROS2_DISTROS,
         help='Target ROS distribution')
     parser.add_argument(
         '-r', '--rmw',

--- a/cross_compile/ros2_cross_compile.py
+++ b/cross_compile/ros2_cross_compile.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Executable for cross-compiling ROS2 packages."""
+"""Executable for cross-compiling ROS and ROS 2 packages."""
 
 import argparse
 import logging
@@ -46,18 +46,18 @@ def create_arg_parser():
         choices=['ubuntu', 'debian'],
         help='Target OS')
     parser.add_argument(
-        '-d', '--distro',
+        '-d', '--rosdistro',
         required=False,
         type=str,
         default='dashing',
-        choices=['ardent', 'bouncy', 'crystal', 'dashing'],
+        choices=['dashing', 'eloquent', 'kinetic', 'melodic'],
         help='Target ROS distribution')
     parser.add_argument(
         '-r', '--rmw',
         required=False,
         type=str,
         default='fastrtps',
-        choices=['fastrtps', 'opensplice', 'connext'],
+        choices=['fastrtps', 'cyclonedds'],
         help='Target RMW implementation')
     parser.add_argument(
         '--sysroot-base-image',
@@ -77,13 +77,14 @@ def create_arg_parser():
         help="When set to true, this disables Docker's cache when building "
              'the Docker image for the workspace')
     parser.add_argument(
-        '--ros2-workspace',
+        '--ros-workspace',
         required=False,
         type=str,
-        default='ros2_ws',
+        default='ros_ws',
         help="The subdirectory of 'sysroot' that contains your 'src' to be built."
              'The output of the cross compilation will be placed in this directory. '
-             "Defaults to 'ros2_ws'.")
+             "Defaults to 'ros_ws'.")
+
     parser.add_argument(
         '--sysroot-path',
         required=False,
@@ -111,14 +112,14 @@ def main():
     parser = create_arg_parser()
     args = parser.parse_args()
     platform = Platform(
-        args.arch, args.os, args.distro, args.rmw)
+        args.arch, args.os, args.rosdistro, args.rmw)
     docker_args = DockerConfig(
-        args.arch, args.os, args.sysroot_base_image,
+        args.arch, args.os, args.rosdistro, args.sysroot_base_image,
         args.docker_network_mode, args.sysroot_nocache)
 
     # Main pipeline
     sysroot_create = SysrootCompiler(cc_root_dir=args.sysroot_path,
-                                     ros_workspace_dir=args.ros2_workspace,
+                                     ros_workspace_dir=args.ros_workspace,
                                      platform=platform,
                                      docker_config=docker_args,
                                      custom_setup_script_path=args.custom_setup_script)

--- a/cross_compile/sysroot_compiler.py
+++ b/cross_compile/sysroot_compiler.py
@@ -22,7 +22,6 @@ import shutil
 from string import Template
 import tarfile
 import tempfile
-from typing import Dict
 from typing import Optional
 
 import docker
@@ -54,7 +53,7 @@ SYSROOT_NOT_FOUND_ERROR_STRING = Template(
 
 SYSROOT_DIR_NAME = 'sysroot'  # type: str
 QEMU_DIR_NAME = 'qemu-user-static'  # type: str
-ROS2_DOCKERFILE_NAME = 'Dockerfile_ros2'  # type: str
+ROS_DOCKERFILE_NAME = 'Dockerfile_ros'  # type: str
 DOCKER_CLIENT = docker.from_env()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -71,11 +70,14 @@ class Platform:
     4. RMW implementation used
     """
 
-    def __init__(self, arch: str, os: str, distro: str, rmw: str):
+    _SUPPORTED_ROS2_DISTROS = ['dashing', 'eloquent']
+    _SUPPORTED_ROS_DISTROS = ['kinetic', 'melodic']
+
+    def __init__(self, arch: str, os: str, rosdistro: str, rmw: str):
         """Initialize platform parameters."""
         self.arch = arch
         self.os = os
-        self.distro = distro
+        self.rosdistro = rosdistro
         self.rmw = rmw
 
         if self.arch == 'armhf':
@@ -83,9 +85,14 @@ class Platform:
         elif self.arch == 'aarch64':
             self.cc_toolchain = 'aarch64-linux-gnu'
 
+        if self.rosdistro in self._SUPPORTED_ROS2_DISTROS:
+            self.ros_version = 'ROS2'
+        elif self.rosdistro in self._SUPPORTED_ROS_DISTROS:
+            self.ros_version = 'ROS'
+
     def __str__(self):
         """Return string representation of platform parameters."""
-        return '-'.join((self.arch, self.os, self.rmw, self.distro))
+        return '-'.join((self.arch, self.os, self.rmw, self.rosdistro))
 
     def get_workspace_image_tag(self) -> str:
         """Generate docker image name and tag."""
@@ -102,21 +109,51 @@ class DockerConfig:
     3. Setting to enable/disable caching during docker build
     """
 
-    _default_docker_base_image = {
-        ('armhf', 'ubuntu'): 'arm32v7/ubuntu:bionic',
-        ('armhf', 'debian'): 'arm32v7/debian:latest',
-        ('aarch64', 'ubuntu'): 'arm64v8/ubuntu:bionic',
-        ('aarch64', 'debian'): 'arm64v8/debian:latest',
-    }  # type: Dict[tuple, str]
+    @staticmethod
+    def _get_docker_base_image(arch, os, rosdistro) -> str:
+        """
+        Return docker image to use in dockerfile used to cross compile.
+
+        Args:
+            arch: Target architecture of cross compiling
+            os: Target OS of cross compiling
+            rosdistro: ROS distribution that is being cross compiled
+
+        Returns:
+            image_name: Docker image name to use in the dockerfile
+        """
+        base_image = ''
+        tag = ''
+
+        if str(arch) == 'armhf':
+            base_image = 'arm32v7'
+        elif str(arch) == 'aarch64':
+            base_image = 'arm64v8'
+
+        if str(os) == 'ubuntu':
+            if str(rosdistro) == 'kinetic' or str(rosdistro) == 'ardent':
+                tag = 'xenial'
+            else:
+                tag = 'bionic'
+        else:
+            if str(rosdistro) == 'kinetic':
+                tag = 'jessie'
+            elif str(rosdistro) == 'eloquent':
+                tag = 'buster'
+            else:
+                tag = 'stretch'
+
+        image_name = base_image + '/' + str(os) + ':' + tag
+        return image_name
 
     def __init__(
-        self, arch: str, os: str, sysroot_base_image: str,
+        self, arch: str, os: str, rosdistro: str, sysroot_base_image: str,
         docker_network_mode: str, sysroot_nocache: bool
     ):
         """Initialize docker configuration."""
         if sysroot_base_image is None:
             self.base_image = \
-                self._default_docker_base_image[arch, os]
+                self._get_docker_base_image(arch, os, rosdistro)
         else:
             self.base_image = sysroot_base_image
 
@@ -170,9 +207,9 @@ class SysrootCompiler:
         self._ros_workspace_relative_to_sysroot = ros_workspace_dir
         self._ros_workspace_dir = self._target_sysroot / self._ros_workspace_relative_to_sysroot
         self._qemu_directory = self._target_sysroot / QEMU_DIR_NAME
-        self._dockerfile_directory = Path(__file__).parent / ROS2_DOCKERFILE_NAME
+        self._dockerfile_directory = Path(__file__).parent / ROS_DOCKERFILE_NAME
         self._expected_dockerfile_directory = (
-            self._target_sysroot / ROS2_DOCKERFILE_NAME)
+            self._target_sysroot / ROS_DOCKERFILE_NAME)
         self._system_setup_script_path = Path()
         self._build_setup_script_path = Path()
         self._platform = platform
@@ -217,7 +254,7 @@ class SysrootCompiler:
             str(self._dockerfile_directory), str(self._target_sysroot))
         if not self._expected_dockerfile_directory.exists():
             raise FileNotFoundError(COPY_DOCKER_WS_ERROR_STRING.substitute(
-                dockerfile=ROS2_DOCKERFILE_NAME))
+                dockerfile=ROS_DOCKERFILE_NAME))
         custom_script_dest = str(self._target_sysroot / 'user-custom-setup')
         if custom_script:
             shutil.copy(custom_script, custom_script_dest)
@@ -231,9 +268,11 @@ class SysrootCompiler:
         DOCKER_CLIENT.images.pull(self._docker_config.base_image)
         image_tag = self._platform.get_workspace_image_tag()
         buildargs = {
-            'ROS2_BASE_IMG': self._docker_config.base_image,
+
+            'BASE_IMAGE': self._docker_config.base_image,
             'ROS2_WORKSPACE': self._ros_workspace_relative_to_sysroot,
-            'ROS_DISTRO': self._platform.distro,
+            'ROS_VERSION': self._platform.ros_version,
+            'ROS_DISTRO': self._platform.rosdistro,
             'TARGET_TRIPLE': self._platform.cc_toolchain,
             'TARGET_ARCH': self._platform.arch,
         }
@@ -282,7 +321,7 @@ class SysrootCompiler:
             sysroot_container = DOCKER_CLIENT.containers.run(
                 image=image_tag, detach=True)
             install_stream, install_stat = sysroot_container.get_archive(
-                '/ros2_ws/install_{}'.format(self._platform.arch))
+                '/ros_ws/install_{}'.format(self._platform.arch))
             install_tar_file.writelines(install_stream)
             sysroot_container.stop()
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
          [os.path.join('resource', package_name)]),
     ],
     package_data={
-        package_name: ['Dockerfile_ros2']
+        package_name: ['Dockerfile_ros']
     },
     install_requires=[
         'setuptools',

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -63,11 +63,11 @@ setup(){
   # Usage: setup CONTAINER_NAME
   test_sysroot_dir=$(mktemp -d)
   mkdir "$test_sysroot_dir/sysroot"
-  mkdir -p "$test_sysroot_dir/sysroot/ros2_ws/src/"
+  mkdir -p "$test_sysroot_dir/sysroot/ros_ws/src/"
   # Get full directory name of the script no matter where it is being called from
   dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
   # Copy dummy pkg
-  cp -r "$dir/dummy_pkg" "$test_sysroot_dir/sysroot/ros2_ws/src"
+  cp -r "$dir/dummy_pkg" "$test_sysroot_dir/sysroot/ros_ws/src"
   # Copy QEMU binaries
   mkdir -p "$test_sysroot_dir/sysroot/qemu-user-static"
   cp /usr/bin/qemu-* "$test_sysroot_dir/sysroot/qemu-user-static"
@@ -123,7 +123,7 @@ fi
 
 # Run the cross compilation script
 log "Executing cross compilation script..."
-ros2 run cross_compile cross_compile --arch "$arch" --os "$os" --distro "$distro" --rmw "$rmw" \
+ros2 run cross_compile cross_compile --arch "$arch" --os "$os" --rosdistro "$distro" --rmw "$rmw" \
                                         --sysroot-path "$test_sysroot_dir"
 CC_SCRIPT_STATUS=$?
 if [[ "$CC_SCRIPT_STATUS" -ne 0 ]]; then

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -139,7 +139,7 @@ if [[ "$IS_CONTAINER_RUNNING" != "true" ]]; then
 fi
 
 log "Executing node in Docker container..."
-docker exec -t "$CONTAINER_NAME" bash -c "source /ros2_ws/install_${arch}/local_setup.bash && dummy_binary"
+docker exec -t "$CONTAINER_NAME" bash -c "source /ros_ws/install_${arch}/local_setup.bash && dummy_binary"
 IS_PUBLISHER_RUNNING=$?
 if [[ "IS_PUBLISHER_RUNNING" -ne 0 ]]; then
   panic "Failed to run the dummy binary in the Docker container."
@@ -147,7 +147,7 @@ fi
 log "Stopping Docker container..."
 docker stop -t 2 "$CONTAINER_NAME"
 
-install_dir=$test_sysroot_dir/sysroot/ros2_ws/install_$arch
+install_dir=$test_sysroot_dir/sysroot/ros_ws/install_$arch
 
 log "Checking that install directory was output to the correct place..."
 if [ ! -d "$install_dir" ]; then
@@ -155,7 +155,7 @@ if [ ! -d "$install_dir" ]; then
 fi
 
 log "Checking that extraction didn't overwrite our workspace"
-if [ ! -d "$test_sysroot_dir/sysroot/ros2_ws/src" ]; then
+if [ ! -d "$test_sysroot_dir/sysroot/ros_ws/src" ]; then
   panic "The user's source tree got deleted by the build"
 fi
 


### PR DESCRIPTION
* Rename `Dockerfile_ros2` to `Dockerfile_ros`
* Rename CLI argument `--distro` to `--rosdistro`
* Reword documentation and variables from `ros2` to `ros`
* Add ROS build support in emulated build
* Add logic to use correct base docker images for supported ROS distros

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>