### PR TITLE
Remove Microsoft's repos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,12 @@ jobs:
       matrix:
           linter: [copyright, flake8, pep257]
     steps:
-    - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros2@0.0.5
-    - uses: ros-tooling/action-ros2-lint@0.0.3
-      with:
-        linter: ${{ matrix.linter }}
-        package-name: cross_compile
+      - name: "Temporarily remove MS apt sources. https://github.com/ros-security/aws-oncall/issues/31"
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+      - uses: actions/checkout@v1
+      - uses: ros-tooling/setup-ros2@0.0.5
+      - uses: ros-tooling/action-ros2-lint@0.0.3
+        with:
+          linter: ${{ matrix.linter }}
+          package-name: cross_compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,38 +17,42 @@ jobs:
       matrix:
           os: [macOS-latest, ubuntu-18.04]
     steps:
-    - uses: ros-tooling/setup-ros2@0.0.5
-    - uses: ros-tooling/action-ros2-ci@0.0.5
-      with:
-        package-name: cross_compile
-    - uses: codecov/codecov-action@v1
-      # Prevent being rate limited by only reporting coverage from the Ubuntu
-      # build.
-      if: matrix.os == 'ubuntu-18.04'
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ros2_ws/src/cross_compile/coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        yml: ./codecov.yml
-        fail_ci_if_error: true
-    - uses: actions/upload-artifact@master
-      with:
-        name: colcon-logs-${{ matrix.os }}
-        path: ros2_ws/log
-    # Upload the package to the PyPI test repository.
-    # This will silently fail if a package with this version number already
-    # exists.
-    - uses: ros-tooling/action-pypi@0.0.1
-      # As the package is platform-independent, only trigger this step on Linux
-      # and only on push.
-      # This action should never happen on pull-request, as it would lead us
-      # to upload the package in its initial state, before review.
-      # The final state of the pull request would then never be uploaded, as
-      # we cannot overwrite packages.
-      if: matrix.os == 'ubuntu-18.04' && github.event_name == 'push'
-      with:
-        package-directory: ros2_ws/src/cross_compile
-        username: ${{ secrets.PYPI_USERNAME }}
-        password: ${{ secrets.PYPI_PASSWORD }}
-        repository-url: https://test.pypi.org/legacy/
+      - name: "Temporarily remove MS apt sources. https://github.com/ros-security/aws-oncall/issues/31"
+        if: matrix.os == 'ubuntu-18.04'
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+      - uses: ros-tooling/setup-ros2@0.0.5
+      - uses: ros-tooling/action-ros2-ci@0.0.5
+        with:
+          package-name: cross_compile
+      - uses: codecov/codecov-action@v1
+        # Prevent being rate limited by only reporting coverage from the Ubuntu
+        # build.
+        if: matrix.os == 'ubuntu-18.04'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ros2_ws/src/cross_compile/coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          yml: ./codecov.yml
+          fail_ci_if_error: true
+      - uses: actions/upload-artifact@master
+        with:
+          name: colcon-logs-${{ matrix.os }}
+          path: ros2_ws/log
+      # Upload the package to the PyPI test repository.
+      # This will silently fail if a package with this version number already
+      # exists.
+      - uses: ros-tooling/action-pypi@0.0.1
+        # As the package is platform-independent, only trigger this step on Linux
+        # and only on push.
+        # This action should never happen on pull-request, as it would lead us
+        # to upload the package in its initial state, before review.
+        # The final state of the pull request would then never be uploaded, as
+        # we cannot overwrite packages.
+        if: matrix.os == 'ubuntu-18.04' && github.event_name == 'push'
+        with:
+          package-directory: ros2_ws/src/cross_compile
+          username: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Add a step to the build and test workflow removing the MS repos causing the workflow to fail.

A PR that reverts this change needs to be created and merged once an official fix has been released.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>