### PR TITLE
Remove RMW string from docker image name

### DIFF
--- a/cross_compile/sysroot_compiler.py
+++ b/cross_compile/sysroot_compiler.py
@@ -92,7 +92,7 @@ class Platform:
 
     def __str__(self):
         """Return string representation of platform parameters."""
-        return '-'.join((self.arch, self.os, self.rmw, self.rosdistro))
+        return '-'.join((self.arch, self.os, self.rosdistro))
 
     def get_workspace_image_tag(self) -> str:
         """Generate docker image name and tag."""

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -107,8 +107,8 @@ do
 done
 
 # Expected name of the container
-readonly CONTAINER_NAME="cc-$arch-$os-$rmw-$distro"
-readonly CONTAINER_TAG="$USER/$arch-$os-$rmw-$distro:latest"
+readonly CONTAINER_NAME="cc-$arch-$os-$distro"
+readonly CONTAINER_TAG="$USER/$arch-$os-$distro:latest"
 # Create trap to make sure all artifacts are removed on exit
 trap 'cleanup $CONTAINER_NAME $result' EXIT
 


### PR DESCRIPTION
Since ROS does not have the concept of DDS/RMW, remove it from the docker image name produced by the script.

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>