### PR TITLE
Add armhf platform to e2e tests

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        supported_platforms: [aarch64]
+        supported_platforms: [aarch64, armhf]
         supported_os: [ubuntu, debian]
         rosdistro: [dashing, eloquent, melodic]
     steps:

--- a/cross_compile/Dockerfile_ros
+++ b/cross_compile/Dockerfile_ros
@@ -36,11 +36,13 @@ ENV LC_ALL C.UTF-8
 
 # Add the ros apt repo
 RUN apt-get update && apt-get install -y \
-        curl \
+        wget \
         gnupg2 \
         lsb-release \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' \
+    --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 \
+    && apt-get clean && apt-get update
 
 RUN echo "deb http://packages.ros.org/${ROS_VERSION}/ubuntu `lsb_release -cs` main" \
     > /etc/apt/sources.list.d/${ROS_VERSION}-latest.list

--- a/cross_compile/Dockerfile_ros
+++ b/cross_compile/Dockerfile_ros
@@ -105,7 +105,7 @@ WORKDIR /ros_ws
 ENV ROSDEP_SKIP_KEYS="console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
 
 RUN rm -f /etc/ros/rosdep/sources.list.d/20-default.list
-RUN rosdep init
+RUN c_rehash /etc/ssl/certs && rosdep init
 RUN rosdep update && \
     apt-get update && \
     rosdep install --from-paths src \

--- a/cross_compile/Dockerfile_ros
+++ b/cross_compile/Dockerfile_ros
@@ -36,7 +36,6 @@ ENV LC_ALL C.UTF-8
 
 # Add the ros apt repo
 RUN apt-get update && apt-get install -y \
-        wget \
         gnupg2 \
         lsb-release \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Changes had to be made to the dockerfile for it to work correctly with Debian Buster and find correct sources lists from rosdep.

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>