### PR TITLE
Allow user to provide custom data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,17 +4,7 @@ __pycache__/
 .eggs/
 
 .idea/
-.gitignore
 
-build/
-install/
-log/
-qemu-user-static/
-src/
-*armhf-*/
-*_armhf-*/
-*aarch64-*/
-*_aarch64-*/
-*_x86-*/
+sysroot/
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cp /usr/bin/qemu-*-static sysroot/qemu-user-static/
 #### 3. Prepare ros_ws
 Use [ROS](http://wiki.ros.org/ROS/Installation) or [ROS 2](https://index.ros.org/doc/ros2/Installation/) source installation guide to get the ROS repositories needed to cross compile.
 
-Once you have the desired sources, copy them in the `sysroot` to use with the tool. 
+Once you have the desired sources, copy them in the `sysroot` to use with the tool.
 ```bash
 # Copy ros sources into the sysroot directory
 cp -r <full_path_to_your_ros_ws>/src sysroot/ros_ws/src
@@ -148,6 +148,43 @@ apt-get install -y software-properties-common
 add-apt-repository ppa:rpi-distro/ppa
 apt-get install -y pigpio
 ```
+
+### Custom Data Directory
+
+Your Custom Setup Script (see above) may need some data that is not accessible within the sysroot creation environment.
+For example, you have custom rosdep rules files that need to be installed to find your dependencies.
+For this use case, you can use the option `--custom-data-dir` to point to an arbitrary path, which will be copied into the environment, and available for use by your custom setup script.
+Within the custom setup script, the data is available at `./custom-data/`
+
+**Example:**
+
+Custom data directory (`/arbitrary/local/directory`)
+```
+/arbitrary/local/directory/
++-- my-data/
+|   +-- something.txt
+```
+
+Setup Script (`/path/to/custom-setup.sh`)
+
+```
+#!/bin/bash
+cat custom-data/something.txt
+```
+
+Tool invocation:
+
+```
+ros2 run cross_compile cross_compile --sysroot-path /absolute/path/to/sysroot \
+                                     --arch aarch64 --os ubuntu \
+                                     --custom-setup-script /path/to/custom-setup.sh \
+                                     --custom-data-dir /arbitrary/local/directory
+```
+
+Now, during the sysroot creation process, you should see the contents of `something.txt` printed during the execution of the custom script.
+
+NOTE: For trivial text files, as in the example above, you could just as easily create those files fully within the `--custom-setup-script`. However, for binary data such as precompiled libraries, this feature comes to the rescue.
+
 
 ## License
 

--- a/cross_compile/Dockerfile_ros
+++ b/cross_compile/Dockerfile_ros
@@ -90,7 +90,8 @@ RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
     && rm -rf /var/lib/apt/lists/*; \
   fi
 
-# Run arbitrary user setup
+# Run arbitrary user setup (copy data and run script)
+COPY custom-data/ custom-data/
 COPY user-custom-setup .
 RUN chmod +x ./user-custom-setup && \
     ./user-custom-setup && \

--- a/cross_compile/Dockerfile_ros
+++ b/cross_compile/Dockerfile_ros
@@ -91,7 +91,7 @@ RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
   fi
 
 # Run arbitrary user setup (copy data and run script)
-COPY custom-data/ custom-data/
+COPY user-custom-data/ custom-data/
 COPY user-custom-setup .
 RUN chmod +x ./user-custom-setup && \
     ./user-custom-setup && \

--- a/cross_compile/ros2_cross_compile.py
+++ b/cross_compile/ros2_cross_compile.py
@@ -103,6 +103,14 @@ def create_arg_parser():
              'adding extra apt sources that rosdep may not handle, or other arbitrary setup that '
              'is specific to your application build. See the section on "Custom Setup Script" '
              'in the README.md for more details.')
+    parser.add_argument(
+        '--custom-data-dir',
+        required=False,
+        default=None,
+        type=str,
+        help='Provide a path to a custom arbitrary to make available the sysroot container. '
+             'You may use this data in your --custom-setup-script. '
+             'It will be available as "custom_data/" in the working directory.')
     return parser
 
 
@@ -122,7 +130,8 @@ def main():
                                      ros_workspace_dir=args.ros_workspace,
                                      platform=platform,
                                      docker_config=docker_args,
-                                     custom_setup_script_path=args.custom_setup_script)
+                                     custom_setup_script_path=args.custom_setup_script,
+                                     custom_data_dir_path=args.custom_data_dir)
     sysroot_create.execute_cc_pipeline()
 
 

--- a/cross_compile/ros2_cross_compile.py
+++ b/cross_compile/ros2_cross_compile.py
@@ -108,9 +108,9 @@ def create_arg_parser():
         required=False,
         default=None,
         type=str,
-        help='Provide a path to a custom arbitrary to make available the sysroot container. '
-             'You may use this data in your --custom-setup-script. '
-             'It will be available as "custom_data/" in the working directory.')
+        help='Provide a path to a custom arbitrary directory to copy into the sysroot container. '
+             'You may use this data in your --custom-setup-script, it will be available as '
+             '"./custom_data/" in the current working directory when the script is run.')
     return parser
 
 
@@ -131,7 +131,7 @@ def main():
                                      platform=platform,
                                      docker_config=docker_args,
                                      custom_setup_script_path=args.custom_setup_script,
-                                     custom_data_dir_path=args.custom_data_dir)
+                                     custom_data_dir=args.custom_data_dir)
     sysroot_create.execute_cc_pipeline()
 
 

--- a/cross_compile/sysroot_compiler.py
+++ b/cross_compile/sysroot_compiler.py
@@ -178,7 +178,7 @@ class SysrootCompiler:
         :param custom_setup_script_path: Optional path to a custom setup script
                                          to run arbitrary commands
         :param custom_data_dir: Optional path to a custom directory of data that
-                                     custom_setup_script can utilize
+                                `custom_setup_script` can utilize
         """
         if not isinstance(cc_root_dir, str):
             raise TypeError('Argument `cc_root_dir` must be of type string.')

--- a/cross_compile/sysroot_compiler.py
+++ b/cross_compile/sysroot_compiler.py
@@ -161,8 +161,8 @@ class SysrootCompiler:
       ros_workspace_dir: str,
       platform: Platform,
       docker_config: DockerConfig,
-      custom_setup_script_path: Optional[str],
-      custom_data_dir_path: Optional[str],
+      custom_setup_script_path: Optional[str] = None,
+      custom_data_dir: Optional[str] = None,
     ) -> None:
         """
         Construct a SysrootCompiler object building ROS 2 Docker container.
@@ -177,7 +177,7 @@ class SysrootCompiler:
                               of the Docker image to build.
         :param custom_setup_script_path: Optional path to a custom setup script
                                          to run arbitrary commands
-        :param custom_data_dir_path: Optional path to a custom directory of data that
+        :param custom_data_dir: Optional path to a custom directory of data that
                                      custom_setup_script can utilize
         """
         if not isinstance(cc_root_dir, str):
@@ -203,7 +203,7 @@ class SysrootCompiler:
         self._build_setup_script_path = Path()
         self._platform = platform
         self._docker_config = docker_config
-        self._setup_sysroot_dir(custom_setup_script_path, custom_data_dir_path)
+        self._setup_sysroot_dir(custom_setup_script_path, custom_data_dir)
 
     def get_system_setup_script_path(self) -> Path:
         """Return the path to the system setup script."""
@@ -247,13 +247,15 @@ class SysrootCompiler:
                 dockerfile=ROS_DOCKERFILE_NAME))
         logger.debug('Copied Dockerfile')
 
-        custom_data_dest = str(self._target_sysroot / 'custom-data')
-        shutil.rmtree(custom_data_dest)  # should not be there unless explicitly specified
+        custom_data_dest = str(self._target_sysroot / 'user-custom-data')
+        shutil.rmtree(
+            custom_data_dest, ignore_errors=True
+        )  # should not be there unless explicitly specified
         if custom_data:
             shutil.copytree(custom_data, custom_data_dest)
             logger.debug('Custom data dir provided - copied')
         else:
-            os.mkdirs(custom_data_dest)
+            os.makedirs(custom_data_dest)
             logger.debug('No custom data dir provided - touched empty dir')
 
         custom_script_dest = str(self._target_sysroot / 'user-custom-setup')

--- a/test/custom-setup-with-data.sh
+++ b/test/custom-setup-with-data.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "This custom setup script uses the custom data dir."
+cat custom-data/arbitrary.txt

--- a/test/custom-setup.sh
+++ b/test/custom-setup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "This is a custom setup script for the sysroot environment."

--- a/test/data/arbitrary.txt
+++ b/test/data/arbitrary.txt
@@ -1,0 +1,1 @@
+This is a test file with text in it.

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -1,3 +1,0 @@
-# TODO: Remove this once we get our own dockerhub repo
-$(aws ecr get-login --no-include-email --region us-east-2)
-py.test test_sysroot_creator.py

--- a/test/test_sysroot_compiler.py
+++ b/test/test_sysroot_compiler.py
@@ -16,6 +16,7 @@
 """Unit tests for the `create_cc_sysroot.py` script."""
 
 import getpass
+import os
 from pathlib import Path
 from typing import Tuple
 
@@ -27,6 +28,8 @@ from cross_compile.sysroot_compiler import SYSROOT_DIR_NAME
 from cross_compile.sysroot_compiler import SysrootCompiler
 import docker
 import pytest
+
+THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def _default_docker_kwargs() -> dict:
@@ -99,11 +102,28 @@ def test_sysroot_compiler_constructor(
     # Create mock directories and files
     sysroot_dir, ros_workspace_dir = setup_mock_sysroot(tmpdir)
     sysroot_compiler = SysrootCompiler(
-        str(tmpdir), 'ros_ws', platform_config,
-        docker_config, None)
+        str(tmpdir), 'ros_ws', platform_config, docker_config)
 
     assert isinstance(sysroot_compiler.get_build_setup_script_path(), Path)
     assert isinstance(sysroot_compiler.get_system_setup_script_path(), Path)
+
+
+def test_custom_setup_script(platform_config, docker_config, tmpdir):
+    sysroot_dir, ros_workspace_dir = setup_mock_sysroot(tmpdir)
+    compiler = SysrootCompiler(
+        str(tmpdir), 'ros_ws', platform_config, docker_config,
+        custom_setup_script_path=os.path.join(THIS_SCRIPT_DIR, 'custom-setup.sh'))
+    assert compiler
+    assert (sysroot_dir / 'user-custom-setup').exists()
+
+
+def test_custom_data_dir(platform_config, docker_config, tmpdir):
+    sysroot_dir, ros_workspace_dir = setup_mock_sysroot(tmpdir)
+    compiler = SysrootCompiler(
+        str(tmpdir), 'ros_ws', platform_config, docker_config,
+        custom_data_dir=os.path.join(THIS_SCRIPT_DIR, 'data'))
+    assert compiler
+    assert (sysroot_dir / 'user-custom-data' / 'arbitrary.txt').exists()
 
 
 def test_sysroot_compiler_tree_validation(platform_config, docker_config, tmpdir):


### PR DESCRIPTION
Provide a new commandline option (and corresponding documentation) for a user to have arbitrary custom data included in the sysroot creation process. This data is available to the custom script that the user can provide.

Fixes #103 