### PR TITLE
Fix and add unit test for incorrect BuildError constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.pyc
 *.egg-info/
+.eggs/
 
 .idea/
 .gitignore

--- a/cross_compile/sysroot_compiler.py
+++ b/cross_compile/sysroot_compiler.py
@@ -277,6 +277,11 @@ class SysrootCompiler:
             nocache=self._docker_config.nocache,
             network_mode=self._docker_config.network_mode,
             decode=True)
+        self._parse_build_output(log_generator)
+
+        logger.info('Successfully created sysroot docker image: %s', image_tag)
+
+    def _parse_build_output(self, log_generator) -> None:
         for chunk in log_generator:
             # There are two outputs we want to capture, stream and error.
             # We also want to remove newline (\n) and carriage returns (\r) to
@@ -286,13 +291,11 @@ class SysrootCompiler:
                 logger.exception(
                     'Error building sysroot image. The following error was caught:\n%s',
                     error_line)
-                raise docker.errors.BuildError(reason=error_line, build_log=error_line)
+                raise docker.errors.BuildError(error_line)
             line = chunk.get('stream', '')
             line = line.rstrip().lstrip()
             if line:
                 logger.info(line)
-
-        logger.info('Successfully created sysroot docker image: %s', image_tag)
 
     def export_cross_compiled_build(self) -> None:
         """Done cross compiling, export the build into the ROS workspace."""

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     },
     install_requires=[
         'setuptools',
-        'docker',
+        'docker>=2,<3',
     ],
     zip_safe=True,
     tests_require=[

--- a/test/test_sysroot_compiler.py
+++ b/test/test_sysroot_compiler.py
@@ -25,6 +25,7 @@ from cross_compile.sysroot_compiler import QEMU_DIR_NAME
 from cross_compile.sysroot_compiler import ROS_DOCKERFILE_NAME
 from cross_compile.sysroot_compiler import SYSROOT_DIR_NAME
 from cross_compile.sysroot_compiler import SysrootCompiler
+import docker
 import pytest
 
 
@@ -180,3 +181,51 @@ def test_get_docker_base_image():
     verify_base_docker_images('armhf', 'debian', 'eloquent', 'arm32v7/debian:buster')
     verify_base_docker_images('armhf', 'debian', 'kinetic', 'arm32v7/debian:jessie')
     verify_base_docker_images('armhf', 'debian', 'melodic', 'arm32v7/debian:stretch')
+
+
+def test_parse_docker_build_output(
+        platform_config, docker_config, tmpdir):
+    """Test the SysrootCompiler constructor assuming valid path setup."""
+    # Create mock directories and files
+    sysroot_dir, ros_workspace_dir = setup_mock_sysroot(tmpdir)
+    sysroot_compiler = SysrootCompiler(
+        str(tmpdir), 'ros_ws', platform_config, docker_config, None)
+
+    log_generator_without_errors = [
+        {'stream': ' ---\\u003e a9eb17255234\\n'},
+        {'stream': 'Step 1 : VOLUME /data\\n'},
+        {'stream': ' ---\\u003e Running in abdc1e6896c6\\n'},
+        {'stream': ' ---\\u003e 713bca62012e\\n'},
+        {'stream': 'Removing intermediate container abdc1e6896c6\\n'},
+        {'stream': 'Step 2 : CMD [\\"/bin/sh\\"]\\n'},
+        {'stream': ' ---\\u003e Running in dba30f2a1a7e\\n'},
+        {'stream': ' ---\\u003e 032b8b2855fc\\n'},
+        {'stream': 'Removing intermediate container dba30f2a1a7e\\n'},
+        {'stream': 'Successfully built 032b8b2855fc\\n'},
+    ]
+    # Just expect it not to raise
+    sysroot_compiler._parse_build_output(log_generator_without_errors)
+
+    log_generator_with_errors = [
+        {'stream': ' ---\\u003e a9eb17255234\\n'},
+        {'stream': 'Step 1 : VOLUME /data\\n'},
+        {'stream': ' ---\\u003e Running in abdc1e6896c6\\n'},
+        {'stream': ' ---\\u003e 713bca62012e\\n'},
+        {'stream': 'Removing intermediate container abdc1e6896c6\\n'},
+        {'stream': 'Step 2 : CMD [\\"/bin/sh\\"]\\n'},
+        {'error': ' ---\\COMMAND NOT FOUND\\n'},
+    ]
+    with pytest.raises(docker.errors.BuildError):
+        sysroot_compiler._parse_build_output(log_generator_with_errors)
+
+
+def test_docker_py_version():
+    # Explicitly check a known difference between apt and pip versions
+    with pytest.raises(TypeError):
+        # 1.20 (from pip, which we are not using) API has named arguments
+        err = docker.errors.BuildError(reason='problem', build_log='stuff that happened')
+        assert err
+
+    # 1.10 API (from apt which we are using) does not
+    err = docker.errors.BuildError('problem')
+    assert err

--- a/test/test_sysroot_compiler.py
+++ b/test/test_sysroot_compiler.py
@@ -224,7 +224,6 @@ def test_docker_py_version():
     with pytest.raises(TypeError):
         # 1.20 (from pip, which we are not using) API has named arguments
         err = docker.errors.BuildError(reason='problem', build_log='stuff that happened')
-        assert err
 
     # 1.10 API (from apt which we are using) does not
     err = docker.errors.BuildError('problem')


### PR DESCRIPTION
This issue was revealed by an unrelated network issue in https://github.com/ros-tooling/cross_compile/pull/105/checks?check_run_id=378401015 that caused the docker build to fail.

Fix the issue and add relevant regression tests.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>