### PR TITLE
Add trivial test to call the argparser

### DIFF
--- a/cross_compile/ros2_cross_compile.py
+++ b/cross_compile/ros2_cross_compile.py
@@ -20,6 +20,7 @@ import argparse
 import logging
 import os
 import sys
+from typing import List
 
 from cross_compile.sysroot_compiler import DockerConfig
 from cross_compile.sysroot_compiler import Platform
@@ -29,7 +30,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def create_arg_parser():
+def parse_args(args: List[str]) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
         description='Sysroot creator for cross compilation workflows.')
@@ -111,14 +112,14 @@ def create_arg_parser():
         help='Provide a path to a custom arbitrary directory to copy into the sysroot container. '
              'You may use this data in your --custom-setup-script, it will be available as '
              '"./custom_data/" in the current working directory when the script is run.')
-    return parser
+
+    return parser.parse_args(args)
 
 
 def main():
     """Start the cross-compilation workflow."""
     # Configuration
-    parser = create_arg_parser()
-    args = parser.parse_args()
+    args = parse_args(sys.argv[1:])
     platform = Platform(
         args.arch, args.os, args.rosdistro, args.rmw)
     docker_args = DockerConfig(

--- a/test/test_entrypoint.py
+++ b/test/test_entrypoint.py
@@ -1,0 +1,23 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Unit tests for the `create_cc_sysroot.py` script."""
+
+from cross_compile.ros2_cross_compile import parse_args
+
+
+def test_trivial():
+    args = parse_args(['-a', 'aarch64', '-o', 'ubuntu'])
+    assert args


### PR DESCRIPTION
Increases code coverage and lets us know that the syntax and imports in the entrypoint are ok.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>