### PR TITLE
Install linters exclusively via pip

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = .eggs/*

--- a/package.xml
+++ b/package.xml
@@ -7,14 +7,6 @@
   <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
   <license>Apache 2.0</license>
 
-  <depend>python3-docker</depend>
-
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
-  <test_depend>python3-pytest</test_depend>
-  <test_depend>yamllint</test_depend>
-
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,8 @@ def fetch_ament_lint_dependency_links():
     """
     Construct the dependency links needed to install the eggs for the ament linters.
 
+    TODO(#123): remove the dependency_links logic when we move over to tox
+
     NOTES about dependency links:
     * We are installing ament_lint via a URL because it is not released to PyPI and we are
       no longer depending on rosdep for this pure-python package
@@ -99,10 +101,9 @@ def fetch_ament_lint_dependency_links():
     subprocess.check_call([
         'git', 'clone',
         '--branch', AMENT_LINTER_VERSION,
+        '--depth', '1',
         'https://github.com/ament/ament_lint/', repo_dir],
-      stdout=subprocess.DEVNULL,
-      stderr=subprocess.DEVNULL,
-    )
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     return [
         'file://{base}/{pkg}#egg={pkg}-{version}'.format(
             base=repo_dir, pkg=linter, version=AMENT_LINTER_VERSION)
@@ -131,7 +132,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Topic :: Software Development',
     ],
-    # NOTE: when we upgrade to pip 10, we will need to update to PEP 508 syntax
     dependency_links=fetch_ament_lint_dependency_links(),
     description='A tool to cross-compile ROS 2 packages.',
     long_description=read_readme(),
@@ -148,13 +148,9 @@ setup(
     install_requires=[
         'docker>=2,<3',
         'setuptools',
-        'svn',
     ],
     zip_safe=True,
     tests_require=[
-        'svn',
-        'setuptools_subversion',
-        'setuptools',
         'flake8',
         'flake8-blind-except',
         'flake8-builtins',


### PR DESCRIPTION
Fixes #109 

In preparation for moving over to a pure-python package, this PR removes all `rosdep` dependency requirements.

* Explicitly require the same set of linters and pytest runners specified in the ROS2 source installation guide https://index.ros.org/doc/ros2/Installation/Eloquent/Linux-Development-Setup/
* Add coveragerc to omit eggs, because locally the automatic coverage run (via `pytest-cov`) was taking a long time specifically looking at that directory that is now automatically created (`.gitignore` does not affect this)
* Remove all package dependencies from `package.xml`

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>