### PR TITLE
Nightly PyPi release test

### DIFF
--- a/.github/workflows/pip_e2e_test.yml
+++ b/.github/workflows/pip_e2e_test.yml
@@ -1,6 +1,5 @@
 name: End-to-end testing for ros-cross-compile using PIP (Nightly Canary)
 on:
-  pull_request:
   schedule:
     # Run every morning Pacific Time.
     # Random hour and minute to avoid creating excess traffic during popular times.

--- a/.github/workflows/pip_e2e_test.yml
+++ b/.github/workflows/pip_e2e_test.yml
@@ -1,14 +1,15 @@
-name: End-to-end Production Testing (Nightly)
+name: End-to-end testing for ros-cross-compile using PIP (Nightly Canary)
 on:
+  pull_request:
   schedule:
     # Run every morning Pacific Time.
     # Random hour and minute to avoid creating excess traffic during popular times.
     # Because the test takes a long time (> 30 min) to run, it is configured to run only once a day.
-    - cron:  '17 17 * * *'
+    - cron:  '17 23 * * *'
 
 jobs:
   build_and_test:
-    runs-on: [ubuntu-18.04, macos-latest]
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
@@ -16,9 +17,8 @@ jobs:
         target_os: [ubuntu]
         rosdistro: [dashing]
         install_type:
-          - pip install -e .
-          - pip install -i https://test.pypi.org/simple/ cross-compile
-          - pip install cross-compile
+          - test
+          - prod
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
@@ -29,9 +29,14 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update && sudo apt install -y qemu-user-static
-    - name: Install cross-compile
+    - name: Install ros-cross-compile from Test PyPi
+      if: matrix.install_type == 'test'
       run: |
-        ${{ matrix.install_type }}
+        pip install 'docker>=2,<3'
+        pip install -i https://test.pypi.org/simple/ ros-cross-compile
+    - name: Install ros-cross-compile from Prod PyPi
+      if: matrix.install_type == 'prod'
+      run: pip install ros-cross-compile
     - name: Run end-to-end test
       run: |
         ./test/run_e2e_test.sh -a "${{ matrix.target_arch }}" -o "${{ matrix.target_os }}" -d "${{ matrix.rosdistro }}"

--- a/.github/workflows/prod_test.yml
+++ b/.github/workflows/prod_test.yml
@@ -1,0 +1,37 @@
+name: End-to-end Production Testing (Nightly)
+on:
+  schedule:
+    # Run every morning Pacific Time.
+    # Random hour and minute to avoid creating excess traffic during popular times.
+    # Because the test takes a long time (> 30 min) to run, it is configured to run only once a day.
+    - cron:  '17 17 * * *'
+
+jobs:
+  build_and_test:
+    runs-on: [ubuntu-18.04, macos-latest]
+    strategy:
+      fail-fast: false
+      matrix:
+        target_arch: [aarch64, armhf]
+        target_os: [ubuntu]
+        rosdistro: [dashing]
+        install_type:
+          - pip install -e .
+          - pip install -i https://test.pypi.org/simple/ cross-compile
+          - pip install cross-compile
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Setup python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install -y qemu-user-static
+    - name: Install cross-compile
+      run: |
+        ${{ matrix.install_type }}
+    - name: Run end-to-end test
+      run: |
+        ./test/run_e2e_test.sh -a "${{ matrix.target_arch }}" -o "${{ matrix.target_os }}" -d "${{ matrix.rosdistro }}"


### PR DESCRIPTION
This PR adds 2 new workflows for E2E testing an install from PyPi and TestPyPi.
This PR **should not be merged** until this package is released to both PyPi and TestPyPi.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>