### PR TITLE
Separate rosdep collection from building

### DIFF
--- a/ros_cross_compile/builders.py
+++ b/ros_cross_compile/builders.py
@@ -15,27 +15,27 @@ import logging
 import os
 from pathlib import Path
 
-import docker
+from ros_cross_compile.docker_client import DockerClient
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def run_emulated_docker_build(image_tag: str, workspace_path: Path) -> None:
+def run_emulated_docker_build(
+    docker_client: DockerClient, image_tag: str, workspace_path: Path
+) -> None:
     """
     Spin up a sysroot docker container and run an emulated build inside.
 
     :param image_tag: Docker image that contains all preinstalled dependencies for workspace.
     :param workspace: Absolute path to the user's source workspace.
     """
-    docker_client = docker.from_env()
-    docker_client.containers.run(
-        image=image_tag,
+    docker_client.run_container(
+        image_name=image_tag,
         environment={
             'OWNER_USER': os.getuid(),
         },
         volumes={
-            str(workspace_path): {'bind': '/ros_ws', 'mode': 'rw'},
+            workspace_path: '/ros_ws',
         },
-        remove=True,
     )

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -1,0 +1,75 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from pathlib import Path
+
+from ros_cross_compile.docker_client import DockerClient
+from ros_cross_compile.platform import Platform
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('Rosdep Gatherer')
+
+
+def build_rosdep_image(
+    docker_client: DockerClient, platform: Platform, docker_dir: Path
+) -> str:
+    """
+    Create the Docker image that can collect a workspace's dependencies.
+
+    :param docker_client: Will be used to build the image.
+    :param platform: Information about the target platform.
+    :param docker_dir: Absolute path to directory where this package's Docker assets are.
+    :return The name of the created image
+    """
+    output_tag = 'rcc/rosdep:{arch}-{os_name}-{os_distro}'.format(
+        arch=platform.arch,
+        os_name=platform.os_name,
+        os_distro=platform.os_distro,
+    )
+
+    logger.info('Building rosdep collector image: %s', output_tag)
+    docker_client.build_image(
+        dockerfile_dir=docker_dir,
+        dockerfile_name='rosdep.Dockerfile',
+        tag=output_tag,
+        buildargs={
+            'BASE_IMAGE': platform.native_base_image,
+        },
+    )
+    logger.info('Successfully created rosdep collector image: %s', output_tag)
+    return output_tag
+
+
+def gather_rosdeps(
+    docker_client: DockerClient, image_name: str, workspace: Path, ros_distro: str
+) -> None:
+    """
+    Run the rosdep Docker image, which outputs a script for dependency installation.
+
+    :param docker_client: Will be used to run the container
+    :param image_name: The name of the image produced by `build_rosdep_image`
+    :param workspace: Absolute path to the colcon source workspace.
+    :param ros_distro: ROS Distro to get dependencies from.
+    :return None
+    """
+    logger.info('Running rosdep collector image on workspace...')
+    docker_client.run_container(
+        image_name=image_name,
+        environment={
+            'ROSDISTRO': ros_distro,
+        },
+        volumes={
+            workspace: '/root/ws'
+        },
+    )

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -euxo pipefail
+set -eo pipefail
+
+[ "${ROS_DISTRO}" ] || (echo "ROSDISTRO var unset" && exit 1)
+[ "${TARGET_ARCH}" ] || (echo "TARGET_ARCH var unset" && exit 1)
+[ "${OWNER_USER}" ] || (echo "OWNER_USER var unset" && exit 1)
 
 source /opt/ros/"${ROS_DISTRO}"/setup.bash
 colcon build --mixin "${TARGET_ARCH}"-docker \

--- a/ros_cross_compile/docker/gather_rosdeps.sh
+++ b/ros_cross_compile/docker/gather_rosdeps.sh
@@ -3,27 +3,28 @@ set -euxo pipefail
 
 [ "${ROSDISTRO}" ] || (echo "ROSDISTRO var unset" && exit 1)
 
-ls
-
 if [ ! -d ./src ]; then
   echo "No src directory found at /root/ws, did you remember to mount your workspace?"
   exit 1
 fi
 
 internals_dir=cc_internals
-mkdir -p $internals_dir
-rosdep_script=$internals_dir/install_rosdeps.sh
+mkdir -p "${internals_dir}"
+rosdep_script="${internals_dir}"/install_rosdeps.sh
 
 rosdep update
 
-echo "#!/bin/bash" > $rosdep_script
-echo "set -euxo pipefail" >> $rosdep_script
+cat > "${rosdep_script}" <<EOF
+#!/bin/bash
+set -euxo pipefail
+EOF
+
 rosdep install \
     --from-paths ./src  \
     --ignore-src \
     --simulate \
     -y \
     --rosdistro "${ROSDISTRO}" \
-  >> $rosdep_script
+  >> "${rosdep_script}"
 
-chmod +x $rosdep_script
+chmod +x "${rosdep_script}"

--- a/ros_cross_compile/docker/gather_rosdeps.sh
+++ b/ros_cross_compile/docker/gather_rosdeps.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euxo pipefail
+
+[ "${ROSDISTRO}" ] || (echo "ROSDISTRO var unset" && exit 1)
+
+ls
+
+if [ ! -d ./src ]; then
+  echo "No src directory found at /root/ws, did you remember to mount your workspace?"
+  exit 1
+fi
+
+internals_dir=cc_internals
+mkdir -p $internals_dir
+rosdep_script=$internals_dir/install_rosdeps.sh
+
+rosdep update
+
+echo "#!/bin/bash" > $rosdep_script
+echo "set -euxo pipefail" >> $rosdep_script
+rosdep install \
+    --from-paths ./src  \
+    --ignore-src \
+    --simulate \
+    -y \
+    --rosdistro "${ROSDISTRO}" \
+  >> $rosdep_script
+
+chmod +x $rosdep_script

--- a/ros_cross_compile/docker/rosdep.Dockerfile
+++ b/ros_cross_compile/docker/rosdep.Dockerfile
@@ -1,0 +1,45 @@
+# This Dockerfile describes a layer on a base OS that has:
+#  * Access to the ROS apt repositories
+#  * rosdep installed
+# When `run` against a mounted ROS workspace, output a script that installs its dependencies
+# This image is intended to run in the host architecture for speed -
+# rosdep doesn't differentiate architecture, just OS,
+# so we can run natively on the same target OS and get the same results
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+# Set timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+RUN apt-get update && apt-get install -y \
+        tzdata \
+        locales \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set locale
+RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && \
+    locale-gen && \
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL C.UTF-8
+
+# Add the ros apt repo
+RUN apt-get update && apt-get install -y \
+        gnupg2 \
+        lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
+
+RUN apt-get update && apt-get install -y \
+      python-rosdep \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rosdep init
+COPY gather_rosdeps.sh /root/
+RUN mkdir -p /root/ws
+WORKDIR /root/ws
+ENTRYPOINT ["/root/gather_rosdeps.sh"]

--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -1,0 +1,101 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from pathlib import Path
+from typing import Dict
+from typing import Optional
+
+import docker
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('Docker Client')
+
+
+class DockerClient:
+    """Simplified Docker API for this package's usage patterns."""
+
+    def __init__(self, nocache):
+        self._client = docker.from_env()
+        self._nocache = nocache
+
+    def build_image(
+        self,
+        dockerfile_dir: Path,
+        dockerfile_name: str,
+        tag: str,
+        buildargs: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Build a Docker image from a Dockerfile.
+
+        :param dockerfile_dir: Absolute path to directory where Dockerfile can be found.
+        :param dockerfile_name: The name of the Dockerfile to build.
+        :param tag: What tag to give the created image.
+        :param buildargs: Optional dictionary of str->str to set arguments for the build.
+        :return None
+        :raises docker.errors.BuildError: on build error
+        """
+        # Use low-level API to expose logs for image building
+        docker_api = docker.APIClient(base_url='unix://var/run/docker.sock')
+        log_generator = docker_api.build(
+            path=str(dockerfile_dir),
+            dockerfile=dockerfile_name,
+            tag=tag,
+            buildargs=buildargs,
+            quiet=False,
+            nocache=self._nocache,
+            decode=True,
+        )
+        self._process_build_log(log_generator)
+
+    def _process_build_log(self, log_generator) -> None:
+        for chunk in log_generator:
+            # There are two outputs we want to capture, stream and error.
+            # We also process line breaks.
+            error_line = chunk.get('error', None)
+            if error_line:
+                logger.exception(
+                    'Error building Docker image. The follow error was caught:\n%s'.format(
+                        error_line))
+                raise docker.errors.BuildError(error_line)
+            line = chunk.get('stream', '')
+            line = line.rstrip().lstrip()
+            if line:
+                logger.info(line)
+
+    def run_container(
+        self, image_name: str, environment: Dict[str, str], volumes: Dict[Path, str]
+    ) -> None:
+        """
+        Run a container of an existing image.
+
+        :param image_name: Name of the image to run.
+        :param environment: Map of environment variable names to values.
+        :param volumes: Map of absolute path to a host directory, to str of mount destination.
+        :return None
+        """
+        container = self._client.containers.run(
+            image=image_name,
+            environment=environment,
+            volumes={
+                str(src): {'bind': dest, 'mode': 'rw'}
+                for src, dest in volumes.items()
+            } if volumes else {},
+            remove=True,
+            detach=True,
+            network_mode='host',
+        )
+        logs = container.logs(stream=True)
+        for line in logs:
+            logger.info(line.decode('utf-8').rstrip())

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -119,3 +119,8 @@ class Platform:
     def target_base_image(self) -> str:
         """Name of the base OS Docker image for the target architecture."""
         return self._docker_target_base
+
+    @property
+    def native_base_image(self) -> str:
+        """Name of the base OS Docker image for the host architecture."""
+        return self._docker_native_base

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -17,11 +17,9 @@ import os
 from pathlib import Path
 import shutil
 from string import Template
-from typing import NamedTuple
 from typing import Optional
 
-import docker
-
+from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.platform import Platform
 
 ROS_WS_DIR_ERROR_STRING = Template(
@@ -56,9 +54,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-ToolchainDockerPair = NamedTuple('ToolchainDockerPair', [('toolchain', str), ('docker_base', str)])
-
-
 def _replace_tree(src: Path, dest: Path) -> None:
     """Delete dest and copy the directory src to that location."""
     shutil.rmtree(str(dest), ignore_errors=True)  # it may or may not exist already
@@ -84,7 +79,6 @@ class SysrootCreator:
       cc_root_dir: str,
       ros_workspace_dir: str,
       platform: Platform,
-      docker_no_cache: bool,
       custom_setup_script_path: Optional[str] = None,
       custom_data_dir: Optional[str] = None,
     ) -> None:
@@ -97,7 +91,6 @@ class SysrootCreator:
                                   ROS2 packages (inside a 'src' directory).
         :param platform: A custom object used to specify the the platform for
                          cross-compilation.
-        :param docker_no_cache: If True, disable the Docker cache during image build.
         :param custom_setup_script_path: Optional path to a custom setup script
                                          to run arbitrary commands
         :param custom_data_dir: Optional path to a custom directory of data that
@@ -111,7 +104,6 @@ class SysrootCreator:
         if not isinstance(platform, Platform):
             raise TypeError('Argument `platform` must be of type Platform.')
 
-        self._docker_client = docker.from_env()
         workspace_root = Path(cc_root_dir).resolve()
         self._target_sysroot = workspace_root / SYSROOT_DIR_NAME
         self._ros_workspace_relative_to_sysroot = ros_workspace_dir
@@ -122,7 +114,6 @@ class SysrootCreator:
         self._system_setup_script_path = Path()
         self._build_setup_script_path = Path()
         self._platform = platform
-        self._docker_no_cache = docker_no_cache
         self._setup_sysroot_dir(custom_setup_script_path, custom_data_dir)
 
     def get_system_setup_script_path(self) -> Path:
@@ -198,50 +189,21 @@ class SysrootCreator:
                 custom_script_file.write('#!/bin/sh\necho "No custom setup"\n')
             logger.debug('No custom script provided - created empty script')
 
-    def create_workspace_sysroot_image(self) -> str:
+    def create_workspace_sysroot_image(self, docker_client: DockerClient) -> str:
         """Build the target sysroot docker image and return its full name."""
-        base = self._platform.target_base_image
-        logger.info('Fetching sysroot base image: %s', base)
-        self._docker_client.images.pull(base)
         image_tag = self._platform.sysroot_image_tag
-        buildargs = {
-            'BASE_IMAGE': base,
-            'ROS_WORKSPACE': self._ros_workspace_relative_to_sysroot,
-            'ROS_VERSION': self._platform.ros_version,
-            'ROS_DISTRO': self._platform.ros_distro,
-            'TARGET_ARCH': self._platform.arch,
-        }
-        logger.info('Building workspace image: %s', image_tag)
 
-        # Switch to low-level API to expose build logs
-        docker_api = docker.APIClient(base_url='unix://var/run/docker.sock')
-        # Note the difference:
-        # path – Path to the directory containing the Dockerfile
-        # dockerfile – Path within the build context to the Dockerfile
-        log_generator = docker_api.build(
-            path=str(self._target_sysroot),
-            dockerfile=str(self._final_dockerfile_path),
+        logger.info('Building sysroot image: %s', image_tag)
+        docker_client.build_image(
+            dockerfile_dir=self._target_sysroot,
+            dockerfile_name=ROS_DOCKERFILE_NAME,
             tag=image_tag,
-            buildargs=buildargs,
-            quiet=False,
-            nocache=self._docker_no_cache,
-            decode=True)
-        self._parse_build_output(log_generator)
-
+            buildargs={
+                'BASE_IMAGE': self._platform.target_base_image,
+                'ROS_WORKSPACE': self._ros_workspace_relative_to_sysroot,
+                'ROS_VERSION': self._platform.ros_version,
+                'ROS_DISTRO': self._platform.ros_distro,
+                'TARGET_ARCH': self._platform.arch,
+            }
+        )
         logger.info('Successfully created sysroot docker image: %s', image_tag)
-
-    def _parse_build_output(self, log_generator) -> None:
-        for chunk in log_generator:
-            # There are two outputs we want to capture, stream and error.
-            # We also want to remove newline (\n) and carriage returns (\r) to
-            # avoid mangled output.
-            error_line = chunk.get('error', None)
-            if error_line:
-                logger.exception(
-                    'Error building sysroot image. The following error was caught:\n%s',
-                    error_line)
-                raise docker.errors.BuildError(error_line)
-            line = chunk.get('stream', '')
-            line = line.rstrip().lstrip()
-            if line:
-                logger.info(line)

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+from unittest.mock import Mock
+
+from ros_cross_compile.builders import run_emulated_docker_build
+
+
+def test_emulated_docker_build():
+    # Very simple smoke test to validate that all internal syntax is correct
+    mock_docker_client = Mock()
+    run_emulated_docker_build(mock_docker_client, 'image_tag', Path('dummy_path'))
+    assert mock_docker_client.run_container.call_count == 1

--- a/test/test_docker_client.py
+++ b/test/test_docker_client.py
@@ -1,0 +1,49 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import docker
+import pytest
+
+from ros_cross_compile.docker_client import DockerClient
+
+
+def test_parse_docker_build_output():
+    """Test the SysrootCreator constructor assuming valid path setup."""
+    # Create mock directories and files
+    client = DockerClient(nocache=False)
+    log_generator_without_errors = [
+        {'stream': ' ---\\u003e a9eb17255234\\n'},
+        {'stream': 'Step 1 : VOLUME /data\\n'},
+        {'stream': ' ---\\u003e Running in abdc1e6896c6\\n'},
+        {'stream': ' ---\\u003e 713bca62012e\\n'},
+        {'stream': 'Removing intermediate container abdc1e6896c6\\n'},
+        {'stream': 'Step 2 : CMD [\\"/bin/sh\\"]\\n'},
+        {'stream': ' ---\\u003e Running in dba30f2a1a7e\\n'},
+        {'stream': ' ---\\u003e 032b8b2855fc\\n'},
+        {'stream': 'Removing intermediate container dba30f2a1a7e\\n'},
+        {'stream': 'Successfully built 032b8b2855fc\\n'},
+    ]
+    # Just expect it not to raise
+    client._process_build_log(log_generator_without_errors)
+
+    log_generator_with_errors = [
+        {'stream': ' ---\\u003e a9eb17255234\\n'},
+        {'stream': 'Step 1 : VOLUME /data\\n'},
+        {'stream': ' ---\\u003e Running in abdc1e6896c6\\n'},
+        {'stream': ' ---\\u003e 713bca62012e\\n'},
+        {'stream': 'Removing intermediate container abdc1e6896c6\\n'},
+        {'stream': 'Step 2 : CMD [\\"/bin/sh\\"]\\n'},
+        {'error': ' ---\\COMMAND NOT FOUND\\n'},
+    ]
+    with pytest.raises(docker.errors.BuildError):
+        client._process_build_log(log_generator_with_errors)


### PR DESCRIPTION
* Factor out a shared Docker Client for using for different build stages
* Rosdeps are collected in a native architecture image and output as a script before creating the sysroot
* Use that script in creating the sysroot, so that when workspace sources change the dependencies don't need to be reinstalled

Fixes #106 

Note that as of https://github.com/ros-tooling/cross_compile/pull/127 the build step itself became incremental (see https://github.com/ros-tooling/cross_compile/issues/108) - and this PR makes it the case that the whole process performs an incremental build. But,  #108 will not be closed by this PR because the completion criteria are not fully met - this currently does incremental by default, whereas that ticket asks for full-rebuild by default.