### PR TITLE
Factor out docker operations into a wrapper client class

### DIFF
--- a/ros_cross_compile/builders.py
+++ b/ros_cross_compile/builders.py
@@ -15,27 +15,27 @@ import logging
 import os
 from pathlib import Path
 
-import docker
+from ros_cross_compile.docker_client import DockerClient
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def run_emulated_docker_build(image_tag: str, workspace_path: Path) -> None:
+def run_emulated_docker_build(
+    docker_client: DockerClient, image_tag: str, workspace_path: Path
+) -> None:
     """
     Spin up a sysroot docker container and run an emulated build inside.
 
     :param image_tag: Docker image that contains all preinstalled dependencies for workspace.
     :param workspace: Absolute path to the user's source workspace.
     """
-    docker_client = docker.from_env()
-    docker_client.containers.run(
-        image=image_tag,
+    docker_client.run_container(
+        image_name=image_tag,
         environment={
             'OWNER_USER': os.getuid(),
         },
         volumes={
-            str(workspace_path): {'bind': '/ros_ws', 'mode': 'rw'},
+            workspace_path: '/ros_ws',
         },
-        remove=True,
     )

--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -1,0 +1,107 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from pathlib import Path
+from typing import Dict
+from typing import Optional
+
+import docker
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('Docker Client')
+
+
+class DockerClient:
+    """Simplified Docker API for this package's usage patterns."""
+
+    def __init__(self, nocache):
+        self._client = docker.from_env()
+        self._nocache = nocache
+
+    def build_image(
+        self,
+        dockerfile_dir: Path,
+        dockerfile_name: str,
+        tag: str,
+        buildargs: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Build a Docker image from a Dockerfile.
+
+        :param dockerfile_dir: Absolute path to directory where Dockerfile can be found.
+        :param dockerfile_name: The name of the Dockerfile to build.
+        :param tag: What tag to give the created image.
+        :param buildargs: Optional dictionary of str->str to set arguments for the build.
+        :return None
+        :raises docker.errors.BuildError: on build error
+        """
+        # Use low-level API to expose logs for image building
+        docker_api = docker.APIClient(base_url='unix://var/run/docker.sock')
+        log_generator = docker_api.build(
+            path=str(dockerfile_dir),
+            dockerfile=dockerfile_name,
+            tag=tag,
+            buildargs=buildargs,
+            quiet=False,
+            nocache=self._nocache,
+            decode=True,
+        )
+        self._process_build_log(log_generator)
+
+    def _process_build_log(self, log_generator) -> None:
+        for chunk in log_generator:
+            # There are two outputs we want to capture, stream and error.
+            # We also process line breaks.
+            error_line = chunk.get('error', None)
+            if error_line:
+                logger.exception(
+                    'Error building Docker image. The follow error was caught:\n%s'.format(
+                        error_line))
+                raise docker.errors.BuildError(error_line)
+            line = chunk.get('stream', '')
+            line = line.rstrip()
+            if line:
+                logger.info(line)
+
+    def run_container(
+        self, image_name: str,
+        environment: Dict[str, str] = {},
+        volumes: Dict[Path, str] = {}
+    ) -> None:
+        """
+        Run a container of an existing image.
+
+        :param image_name: Name of the image to run.
+        :param environment: Map of environment variable names to values.
+        :param volumes: Map of absolute path to a host directory, to str of mount destination.
+        :return None
+        """
+        docker_volumes = {
+            str(src): {
+                'bind': dest,
+                'mode': 'rw',
+            }
+            for src, dest in volumes.items()
+        }
+        container = self._client.containers.run(
+            image=image_name,
+            environment=environment,
+            volumes=docker_volumes,
+            remove=True,
+            detach=True,
+            network_mode='host',
+        )
+        logs = container.logs(stream=True)
+        for line in logs:
+            logger.info(line.decode('utf-8').rstrip())

--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -25,9 +25,14 @@ logger = logging.getLogger('Docker Client')
 class DockerClient:
     """Simplified Docker API for this package's usage patterns."""
 
-    def __init__(self, nocache):
+    def __init__(self, disable_cache: bool = False):
+        """
+        Construct the DockerClient.
+
+        :param disable_cache: If True, disable the Docker cache when building images.
+        """
         self._client = docker.from_env()
-        self._nocache = nocache
+        self._disable_cache = disable_cache
 
     def build_image(
         self,
@@ -54,7 +59,7 @@ class DockerClient:
             tag=tag,
             buildargs=buildargs,
             quiet=False,
-            nocache=self._nocache,
+            nocache=self._disable_cache,
             decode=True,
         )
         self._process_build_log(log_generator)

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -121,7 +121,7 @@ def main():
                                      custom_data_dir=args.custom_data_dir)
     sysroot_creator.create_workspace_sysroot_image(docker_client)
     ros_workspace_dir = os.path.join(args.sysroot_path, 'sysroot', args.ros_workspace)
-    run_emulated_docker_build(platform.sysroot_image_tag, ros_workspace_dir)
+    run_emulated_docker_build(docker_client, platform.sysroot_image_tag, ros_workspace_dir)
 
 
 if __name__ == '__main__':

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -23,6 +23,7 @@ import sys
 from typing import List
 
 from ros_cross_compile.builders import run_emulated_docker_build
+from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.platform import Platform
 from ros_cross_compile.platform import SUPPORTED_ARCHITECTURES
 from ros_cross_compile.platform import SUPPORTED_ROS2_DISTROS
@@ -112,13 +113,13 @@ def main():
     # Configuration
     args = parse_args(sys.argv[1:])
     platform = Platform(args.arch, args.os, args.rosdistro, args.sysroot_base_image)
+    docker_client = DockerClient(args.sysroot_nocache)
     sysroot_creator = SysrootCreator(cc_root_dir=args.sysroot_path,
                                      ros_workspace_dir=args.ros_workspace,
                                      platform=platform,
-                                     docker_no_cache=args.sysroot_nocache,
                                      custom_setup_script_path=args.custom_setup_script,
                                      custom_data_dir=args.custom_data_dir)
-    sysroot_creator.create_workspace_sysroot_image()
+    sysroot_creator.create_workspace_sysroot_image(docker_client)
     ros_workspace_dir = os.path.join(args.sysroot_path, 'sysroot', args.ros_workspace)
     run_emulated_docker_build(platform.sysroot_image_tag, ros_workspace_dir)
 

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -17,11 +17,9 @@ import os
 from pathlib import Path
 import shutil
 from string import Template
-from typing import NamedTuple
 from typing import Optional
 
-import docker
-
+from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.platform import Platform
 
 ROS_WS_DIR_ERROR_STRING = Template(
@@ -56,9 +54,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-ToolchainDockerPair = NamedTuple('ToolchainDockerPair', [('toolchain', str), ('docker_base', str)])
-
-
 def _replace_tree(src: Path, dest: Path) -> None:
     """Delete dest and copy the directory src to that location."""
     shutil.rmtree(str(dest), ignore_errors=True)  # it may or may not exist already
@@ -84,7 +79,6 @@ class SysrootCreator:
       cc_root_dir: str,
       ros_workspace_dir: str,
       platform: Platform,
-      docker_no_cache: bool,
       custom_setup_script_path: Optional[str] = None,
       custom_data_dir: Optional[str] = None,
     ) -> None:
@@ -97,7 +91,6 @@ class SysrootCreator:
                                   ROS2 packages (inside a 'src' directory).
         :param platform: A custom object used to specify the the platform for
                          cross-compilation.
-        :param docker_no_cache: If True, disable the Docker cache during image build.
         :param custom_setup_script_path: Optional path to a custom setup script
                                          to run arbitrary commands
         :param custom_data_dir: Optional path to a custom directory of data that
@@ -111,7 +104,6 @@ class SysrootCreator:
         if not isinstance(platform, Platform):
             raise TypeError('Argument `platform` must be of type Platform.')
 
-        self._docker_client = docker.from_env()
         workspace_root = Path(cc_root_dir).resolve()
         self._target_sysroot = workspace_root / SYSROOT_DIR_NAME
         self._ros_workspace_relative_to_sysroot = ros_workspace_dir
@@ -122,7 +114,6 @@ class SysrootCreator:
         self._system_setup_script_path = Path()
         self._build_setup_script_path = Path()
         self._platform = platform
-        self._docker_no_cache = docker_no_cache
         self._setup_sysroot_dir(custom_setup_script_path, custom_data_dir)
 
     def get_system_setup_script_path(self) -> Path:
@@ -198,50 +189,21 @@ class SysrootCreator:
                 custom_script_file.write('#!/bin/sh\necho "No custom setup"\n')
             logger.debug('No custom script provided - created empty script')
 
-    def create_workspace_sysroot_image(self) -> str:
+    def create_workspace_sysroot_image(self, docker_client: DockerClient) -> str:
         """Build the target sysroot docker image and return its full name."""
-        base = self._platform.target_base_image
-        logger.info('Fetching sysroot base image: %s', base)
-        self._docker_client.images.pull(base)
         image_tag = self._platform.sysroot_image_tag
-        buildargs = {
-            'BASE_IMAGE': base,
-            'ROS_WORKSPACE': self._ros_workspace_relative_to_sysroot,
-            'ROS_VERSION': self._platform.ros_version,
-            'ROS_DISTRO': self._platform.ros_distro,
-            'TARGET_ARCH': self._platform.arch,
-        }
-        logger.info('Building workspace image: %s', image_tag)
 
-        # Switch to low-level API to expose build logs
-        docker_api = docker.APIClient(base_url='unix://var/run/docker.sock')
-        # Note the difference:
-        # path – Path to the directory containing the Dockerfile
-        # dockerfile – Path within the build context to the Dockerfile
-        log_generator = docker_api.build(
-            path=str(self._target_sysroot),
-            dockerfile=str(self._final_dockerfile_path),
+        logger.info('Building sysroot image: %s', image_tag)
+        docker_client.build_image(
+            dockerfile_dir=self._target_sysroot,
+            dockerfile_name=ROS_DOCKERFILE_NAME,
             tag=image_tag,
-            buildargs=buildargs,
-            quiet=False,
-            nocache=self._docker_no_cache,
-            decode=True)
-        self._parse_build_output(log_generator)
-
+            buildargs={
+                'BASE_IMAGE': self._platform.target_base_image,
+                'ROS_WORKSPACE': self._ros_workspace_relative_to_sysroot,
+                'ROS_VERSION': self._platform.ros_version,
+                'ROS_DISTRO': self._platform.ros_distro,
+                'TARGET_ARCH': self._platform.arch,
+            }
+        )
         logger.info('Successfully created sysroot docker image: %s', image_tag)
-
-    def _parse_build_output(self, log_generator) -> None:
-        for chunk in log_generator:
-            # There are two outputs we want to capture, stream and error.
-            # We also want to remove newline (\n) and carriage returns (\r) to
-            # avoid mangled output.
-            error_line = chunk.get('error', None)
-            if error_line:
-                logger.exception(
-                    'Error building sysroot image. The following error was caught:\n%s',
-                    error_line)
-                raise docker.errors.BuildError(error_line)
-            line = chunk.get('stream', '')
-            line = line.rstrip().lstrip()
-            if line:
-                logger.info(line)

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+from unittest.mock import Mock
+
+from ros_cross_compile.builders import run_emulated_docker_build
+
+
+def test_emulated_docker_build():
+    # Very simple smoke test to validate that all internal syntax is correct
+    mock_docker_client = Mock()
+    run_emulated_docker_build(mock_docker_client, 'image_tag', Path('dummy_path'))
+    assert mock_docker_client.run_container.call_count == 1

--- a/test/test_docker_client.py
+++ b/test/test_docker_client.py
@@ -20,7 +20,7 @@ from ros_cross_compile.docker_client import DockerClient
 def test_parse_docker_build_output():
     """Test the SysrootCreator constructor assuming valid path setup."""
     # Create mock directories and files
-    client = DockerClient(nocache=False)
+    client = DockerClient()
     log_generator_without_errors = [
         {'stream': ' ---\\u003e a9eb17255234\\n'},
         {'stream': 'Step 1 : VOLUME /data\\n'},

--- a/test/test_docker_client.py
+++ b/test/test_docker_client.py
@@ -1,0 +1,49 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import docker
+import pytest
+
+from ros_cross_compile.docker_client import DockerClient
+
+
+def test_parse_docker_build_output():
+    """Test the SysrootCreator constructor assuming valid path setup."""
+    # Create mock directories and files
+    client = DockerClient(nocache=False)
+    log_generator_without_errors = [
+        {'stream': ' ---\\u003e a9eb17255234\\n'},
+        {'stream': 'Step 1 : VOLUME /data\\n'},
+        {'stream': ' ---\\u003e Running in abdc1e6896c6\\n'},
+        {'stream': ' ---\\u003e 713bca62012e\\n'},
+        {'stream': 'Removing intermediate container abdc1e6896c6\\n'},
+        {'stream': 'Step 2 : CMD [\\"/bin/sh\\"]\\n'},
+        {'stream': ' ---\\u003e Running in dba30f2a1a7e\\n'},
+        {'stream': ' ---\\u003e 032b8b2855fc\\n'},
+        {'stream': 'Removing intermediate container dba30f2a1a7e\\n'},
+        {'stream': 'Successfully built 032b8b2855fc\\n'},
+    ]
+    # Just expect it not to raise
+    client._process_build_log(log_generator_without_errors)
+
+    log_generator_with_errors = [
+        {'stream': ' ---\\u003e a9eb17255234\\n'},
+        {'stream': 'Step 1 : VOLUME /data\\n'},
+        {'stream': ' ---\\u003e Running in abdc1e6896c6\\n'},
+        {'stream': ' ---\\u003e 713bca62012e\\n'},
+        {'stream': 'Removing intermediate container abdc1e6896c6\\n'},
+        {'stream': 'Step 2 : CMD [\\"/bin/sh\\"]\\n'},
+        {'error': ' ---\\COMMAND NOT FOUND\\n'},
+    ]
+    with pytest.raises(docker.errors.BuildError):
+        client._process_build_log(log_generator_with_errors)


### PR DESCRIPTION
Progress toward #106 
Part of replacement for #139

Factors out docker operations into a wrapper DockerClient class that encapsulates our common usage patterns. Will be used for upcoming build stages as well. 