### PR TITLE
Fix workspace builder script when ROS actually installed,

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ This tool supports compiling a workspace for all combinations of the following:
   * ROS 2: `dashing`, `eloquent`
 * OS: `Ubuntu`, `Debian`
 
+NOTE: ROS 2 supports Debian only as a Tier 3 platform.
+This means that there are not `apt` repositories available for the ROS 2 Core on this platform.
+Because of that, when targeting Debian for a ROS 2 workspace, you must also include the source for the core as well.
+It is recommended to use a release branch of `ros2.repos` from https://github.com/ros2/ros2 to do so, rather than `master`, so that you are not affected by development branch bugs and API changes.
+
 ## Supported hosts
 
 This tool officially supports running on the following host systems.

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -euxo pipefail
+set -eo pipefail
+
+[ "${ROS_DISTRO}" ] || (echo "ROSDISTRO var unset" && exit 1)
+[ "${TARGET_ARCH}" ] || (echo "TARGET_ARCH var unset" && exit 1)
+[ "${OWNER_USER}" ] || (echo "OWNER_USER var unset" && exit 1)
 
 source /opt/ros/"${ROS_DISTRO}"/setup.bash
 colcon build --mixin "${TARGET_ARCH}"-docker \

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# No -u because setup.bash for ROS has unset variables
+# No -x because it prints all of setup.bash steps, which are numerous and noisy
 set -eo pipefail
 
 [ "${ROS_DISTRO}" ] || (echo "ROSDISTRO var unset" && exit 1)

--- a/test/dummy_pkg_ros2/CMakeLists.txt
+++ b/test/dummy_pkg_ros2/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(dummy_pkg_ros2)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+
+add_executable(dummy_binary main.cpp)
+ament_target_dependencies(dummy_binary "rclcpp")
+install(TARGETS dummy_binary DESTINATION bin)
+ament_package()

--- a/test/dummy_pkg_ros2/main.cpp
+++ b/test/dummy_pkg_ros2/main.cpp
@@ -1,0 +1,21 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char** argv) {
+  rclcpp::init(argc, argv);
+  auto node = std::make_unique<rclcpp::Node>("dummy_node");
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test/dummy_pkg_ros2/package.xml
+++ b/test/dummy_pkg_ros2/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>dummy_pkg_ros2</name>
+  <version>0.0.0</version>
+  <description>end to end ROS2 test package for cross compiling</description>
+  <maintainer email="example@example.com">Nobody</maintainer>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -69,11 +69,16 @@ setup(){
   # Get full directory name of the script no matter where it is being called from
   dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
   # Copy correct dummy test pkg for the current argument set
-  if [ "$os" == "ubuntu" ] && [ "$ros_version" == "ros2" ]; then
-    cp -r "$dir/dummy_pkg_ros2" "$test_sysroot_dir/sysroot/ros_ws/src"
+  if [ "$ros_version" == "ros2" ] && [ "$os" == "ubuntu" ]; then
+    # ROS2 + Debian info
+    # Debian is a Tier 3 package for current ROS 2 distributions, so it doesn't have apt releases
+    # Therefore we can't resolve the rclcpp dependency of the ros2 package, so we build the empty project
+    test_package_name="dummy_pkg_ros2"
   else
-    cp -r "$dir/dummy_pkg" "$test_sysroot_dir/sysroot/ros_ws/src"
+    test_package_name="dummy_pkg"
   fi
+  cp -r "$dir/$test_package_name" "$test_sysroot_dir/sysroot/ros_ws/src"
+
   # Copy QEMU binaries
   mkdir -p "$test_sysroot_dir/sysroot/qemu-user-static"
   cp /usr/bin/qemu-* "$test_sysroot_dir/sysroot/qemu-user-static"


### PR DESCRIPTION
The `build_workspace.sh` script caused an error upon sourcing `setup.bash` because of unset variables, if ROS was actually installed.

To fix:
* remove the `set -u` option for that script
* add explicit checking for required variables
* update e2e test dummy package to require ROS2

After updating the package but before updating the script, the e2e test failed. Now it succeeds and is performing a more thorough test.

Part of the replacement for #139 

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>