### PR TITLE
Separate gathering rosdeps from sysroot creation

### DIFF
--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -33,27 +33,20 @@ def gather_rosdeps(
     :param docker_dir: Absolute path to directory where Dockerfiles can be found.
     :return None
     """
-    image_name = 'rcc/rosdep:{arch}-{os_name}-{os_distro}'.format(
-        arch=platform.arch,
-        os_name=platform.os_name,
-        os_distro=platform.os_distro,
-    )
+    image_name = 'ros_cross_compile:rosdep'
     logger.info('Building rosdep collector image: %s', image_name)
     docker_client.build_image(
-        docker_dir=docker_dir,
+        dockerfile_dir=docker_dir,
         dockerfile_name='rosdep.Dockerfile',
         tag=image_name,
-        buildargs={
-            'BASE_IMAGE': platform.native_base_image,
-        },
     )
-    logger.info('Successfully created rosdep collector image: %s', image_name)
 
     logger.info('Running rosdep collector image on workspace...')
     docker_client.run_container(
         image_name=image_name,
         environment={
             'ROSDISTRO': platform.ros_distro,
+            'TARGET_OS': '{}:{}'.format(platform.os_name, platform.os_distro),
         },
         volumes={
             workspace: '/root/ws'

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -1,0 +1,61 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from pathlib import Path
+
+from ros_cross_compile.docker_client import DockerClient
+from ros_cross_compile.platform import Platform
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('Rosdep Gatherer')
+
+
+def gather_rosdeps(
+    docker_client: DockerClient, platform: Platform, workspace: Path, docker_dir: Path,
+) -> None:
+    """
+    Run the rosdep Docker image, which outputs a script for dependency installation.
+
+    :param docker_client: Will be used to run the container
+    :param platform: The name of the image produced by `build_rosdep_image`
+    :param workspace: Absolute path to the colcon source workspace.
+    :param docker_dir: Absolute path to directory where Dockerfiles can be found.
+    :return None
+    """
+    image_name = 'rcc/rosdep:{arch}-{os_name}-{os_distro}'.format(
+        arch=platform.arch,
+        os_name=platform.os_name,
+        os_distro=platform.os_distro,
+    )
+    logger.info('Building rosdep collector image: %s', image_name)
+    docker_client.build_image(
+        docker_dir=docker_dir,
+        dockerfile_name='rosdep.Dockerfile',
+        tag=image_name,
+        buildargs={
+            'BASE_IMAGE': platform.native_base_image,
+        },
+    )
+    logger.info('Successfully created rosdep collector image: %s', image_name)
+
+    logger.info('Running rosdep collector image on workspace...')
+    docker_client.run_container(
+        image_name=image_name,
+        environment={
+            'ROSDISTRO': platform.ros_distro,
+        },
+        volumes={
+            workspace: '/root/ws'
+        },
+    )

--- a/ros_cross_compile/docker/gather_rosdeps.sh
+++ b/ros_cross_compile/docker/gather_rosdeps.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
-[ "${ROSDISTRO}" ] || (echo "ROSDISTRO var unset" && exit 1)
+[ "${ROSDISTRO}" ] || (echo "ROSDISTRO variable not set" && exit 1)
+[ "${TARGET_OS}" ] || (echo "TARGET_OS variable not set" && exit 1)
 
 if [ ! -d ./src ]; then
   echo "No src/ directory found at /root/ws, did you remember to mount your workspace?"
@@ -20,11 +21,13 @@ set -euxo pipefail
 EOF
 
 rosdep install \
+    --os "${TARGET_OS}" \
+    --rosdistro "${ROSDISTRO}" \
     --from-paths ./src  \
     --ignore-src \
+    --reinstall \
+    --default-yes \
     --simulate \
-    -y \
-    --rosdistro "${ROSDISTRO}" \
   >> "${rosdep_script}"
 
 chmod +x "${rosdep_script}"

--- a/ros_cross_compile/docker/gather_rosdeps.sh
+++ b/ros_cross_compile/docker/gather_rosdeps.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euxo pipefail
+
+[ "${ROSDISTRO}" ] || (echo "ROSDISTRO var unset" && exit 1)
+
+if [ ! -d ./src ]; then
+  echo "No src/ directory found at /root/ws, did you remember to mount your workspace?"
+  exit 1
+fi
+
+internals_dir=cc_internals
+mkdir -p "${internals_dir}"
+rosdep_script="${internals_dir}"/install_rosdeps.sh
+
+rosdep update
+
+cat > "${rosdep_script}" <<EOF
+#!/bin/bash
+set -euxo pipefail
+EOF
+
+rosdep install \
+    --from-paths ./src  \
+    --ignore-src \
+    --simulate \
+    -y \
+    --rosdistro "${ROSDISTRO}" \
+  >> "${rosdep_script}"
+
+chmod +x "${rosdep_script}"

--- a/ros_cross_compile/docker/rosdep.Dockerfile
+++ b/ros_cross_compile/docker/rosdep.Dockerfile
@@ -1,39 +1,16 @@
-# This Dockerfile describes a layer on a base OS that has:
-#  * Access to the ROS apt repositories
-#  * rosdep installed
-# When `run` against a mounted ROS workspace, output a script that installs its dependencies
-# This image is intended to run in the host architecture for speed -
-# rosdep doesn't differentiate architecture, just OS,
-# so we can run natively on the same target OS and get the same results
-ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
-
-# Set timezone
-RUN echo 'Etc/UTC' > /etc/timezone && \
-    ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+# This Dockerfile describes a simple image with rosdep installed.
+# When `run`, it outputs a script for installing dependencies for a give workspace
+# Requirements:
+#  * mount a colcon workspace at /root/ws
+#  * set environment variable ROS_DISTRO (e.g. ROS_DISTRO=dashing)
+#  * set environment variable TARGET_OS (this is passed directly to rosdep insall --os=, so it is in the format OS_NAME:OS_VERSION, e.g. "ubuntu:bionic")
+FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y \
-        tzdata \
-        locales \
-    && rm -rf /var/lib/apt/lists/*
-
-# Set locale
-RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && \
-    locale-gen && \
-    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LC_ALL C.UTF-8
-
-# Add the ros apt repo
-RUN apt-get update && apt-get install -y \
-        gnupg2 \
-        lsb-release \
+      gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
-
+RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list
 RUN apt-get update && apt-get install -y \
       python-rosdep \
     && rm -rf /var/lib/apt/lists/*

--- a/ros_cross_compile/docker/rosdep.Dockerfile
+++ b/ros_cross_compile/docker/rosdep.Dockerfile
@@ -1,0 +1,45 @@
+# This Dockerfile describes a layer on a base OS that has:
+#  * Access to the ROS apt repositories
+#  * rosdep installed
+# When `run` against a mounted ROS workspace, output a script that installs its dependencies
+# This image is intended to run in the host architecture for speed -
+# rosdep doesn't differentiate architecture, just OS,
+# so we can run natively on the same target OS and get the same results
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+# Set timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+RUN apt-get update && apt-get install -y \
+        tzdata \
+        locales \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set locale
+RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && \
+    locale-gen && \
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL C.UTF-8
+
+# Add the ros apt repo
+RUN apt-get update && apt-get install -y \
+        gnupg2 \
+        lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
+
+RUN apt-get update && apt-get install -y \
+      python-rosdep \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rosdep init
+COPY gather_rosdeps.sh /root/
+RUN mkdir -p /root/ws
+WORKDIR /root/ws
+ENTRYPOINT ["/root/gather_rosdeps.sh"]

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -56,7 +56,6 @@ RUN apt-get update && apt-get install -y \
       python3-colcon-common-extensions \
       python3-colcon-mixin \
       python3-pip \
-      python-rosdep \
       wget \
     && rm -rf /var/lib/apt/lists/*
 
@@ -99,22 +98,11 @@ RUN chmod +x ./user-custom-setup && \
     ./user-custom-setup && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy in ROS workspace
-COPY ${ROS_WORKSPACE}/src /ros_ws/src
-WORKDIR /ros_ws
-
-# Run rosdep to install dependencies for the ROS workspace
-ENV ROSDEP_SKIP_KEYS="console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
-
-RUN rm -f /etc/ros/rosdep/sources.list.d/20-default.list
-RUN c_rehash /etc/ssl/certs && rosdep init
-RUN rosdep update && \
-    apt-get update && \
-    rosdep install --from-paths src \
-        --ignore-src \
-        --rosdistro ${ROS_DISTRO} -y \
-        --skip-keys "${ROSDEP_SKIP_KEYS}" \
-    && rm -rf /var/lib/apt/lists/*
+# Use generated rosdep installation script
+COPY ${ROS_WORKSPACE}/cc_internals/install_rosdeps.sh .
+RUN apt-get update && \
+    ./install_rosdeps.sh && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set up build tools for the workspace
 COPY mixins/ mixins/

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -112,4 +112,5 @@ RUN mkdir -p /opt/ros/${ROS_DISTRO} && \
     touch /opt/ros/${ROS_DISTRO}/setup.sh && \
     touch /opt/ros/${ROS_DISTRO}/setup.bash
 COPY build_workspace.sh /root
+WORKDIR /ros_ws
 ENTRYPOINT ["/root/build_workspace.sh"]

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -119,3 +119,8 @@ class Platform:
     def target_base_image(self) -> str:
         """Name of the base OS Docker image for the target architecture."""
         return self._docker_target_base
+
+    @property
+    def native_base_image(self) -> str:
+        """Name of the base OS Docker image for the host architecture."""
+        return self._docker_native_base

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -119,8 +119,3 @@ class Platform:
     def target_base_image(self) -> str:
         """Name of the base OS Docker image for the target architecture."""
         return self._docker_target_base
-
-    @property
-    def native_base_image(self) -> str:
-        """Name of the base OS Docker image for the host architecture."""
-        return self._docker_native_base

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -14,7 +14,6 @@
 from pathlib import Path
 from unittest.mock import Mock
 
-from ros_cross_compile.dependencies import build_rosdep_image
 from ros_cross_compile.dependencies import gather_rosdeps
 from ros_cross_compile.platform import Platform
 
@@ -22,10 +21,7 @@ from ros_cross_compile.platform import Platform
 def test_smoke():
     # Very simple smoke test to validate that all internal syntax is correct
     platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
-
     mock_docker_client = Mock()
-    image_tag = build_rosdep_image(mock_docker_client, platform, Path('dummy_path'))
+    gather_rosdeps(mock_docker_client, platform, Path('dummy_workspace'), Path('dummy_docker_dir'))
     assert mock_docker_client.build_image.call_count == 1
-
-    gather_rosdeps(mock_docker_client, image_tag, Path('dummy_path'), 'eloquent')
     assert mock_docker_client.run_container.call_count == 1


### PR DESCRIPTION
Preserves the Docker cache on source changes.

* Create a reusable Docker image that has rosdep installed. Thought about just using rosdep on the local system as a python dependency, but this avoids having to run `rosdep init` as root, and avoids the potential issue of python-installed and apt-installed rosdep overlays.
* Runs rosdep against a mounted workspace to output a script for installing dependencies. If the script doesn't change between runs (meaning no dependencies were added or removed), then the sysroot image will use the cache and go straight on to the building step

This has the side effect of also making builds be truly incremental, but doesn't meet full criteria for #108 so I won't close that yet.

Fixes #106 