### PR TITLE
Bump docker-py version to latest major

### DIFF
--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -72,7 +72,7 @@ class DockerClient:
             if error_line:
                 logger.exception(
                     'Error building Docker image. The follow error was caught:\n' + error_line)
-                raise docker.errors.BuildError(error_line)
+                raise docker.errors.BuildError(reason=error_line, build_log=error_line)
             line = chunk.get('stream', '')
             line = line.rstrip()
             if line:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         package_name: ['docker/*.*', 'mixins/*.*'],
     },
     install_requires=[
-        'docker>=2,<3',
+        'docker>=4,<5',
         'setuptools',
     ],
     zip_safe=True,

--- a/test/test_platform.py
+++ b/test/test_platform.py
@@ -87,13 +87,14 @@ def test_get_docker_base_image():
 
 def test_docker_py_version():
     # Explicitly check a known difference between apt and pip versions
-    with pytest.raises(TypeError):
-        # 1.20 (from pip, which we are not using) API has named arguments
-        err = docker.errors.BuildError(reason='problem', build_log='stuff that happened')
-
-    # 1.10 API (from apt which we are using) does not
-    err = docker.errors.BuildError('problem')
+    # 1.20 (from pip, which we are not using) API has 2 positional arguments
+    err = docker.errors.BuildError(reason='problem', build_log='stuff that happened')
     assert err
+
+    with pytest.raises(TypeError):
+        # 1.10 API (from apt) does not
+        err = docker.errors.BuildError('problem')
+        assert err
 
 
 def test_ros_version_map():


### PR DESCRIPTION
We were using a very old version and there's no reason to do so now that we're not dependent on `rosdep`