### PR TITLE
Remove dependencies installed in the sysroot that are not used by anything

### DIFF
--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -52,12 +52,10 @@ RUN echo "deb http://packages.ros.org/${ROS_VERSION}/ubuntu `lsb_release -cs` ma
 RUN apt-get update && apt-get install -y \
       build-essential \
       cmake \
-      git \
       python3-colcon-common-extensions \
       python3-colcon-mixin \
       python3-pip \
       python-rosdep \
-      wget \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install -U \
@@ -66,7 +64,6 @@ RUN python3 -m pip install -U \
 # Install some pip packages needed for testing ROS 2
 RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
     python3 -m pip install -U \
-    argcomplete \
     flake8 \
     flake8-blind-except \
     flake8-builtins \
@@ -81,7 +78,6 @@ RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
     pytest \
     pytest-cov \
     pytest-runner \
-    vcstool; \
   fi
 
 # Install Fast-RTPS dependencies for ROS 2

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -78,15 +78,15 @@ RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
     pytest \
     pytest-cov \
     pytest-runner \
-  fi
+  ; fi
 
 # Install Fast-RTPS dependencies for ROS 2
 RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
     apt-get update && apt-get install --no-install-recommends -y \
         libasio-dev \
         libtinyxml2-dev \
-    && rm -rf /var/lib/apt/lists/*; \
-  fi
+    && rm -rf /var/lib/apt/lists/* \
+  ; fi
 
 # Run arbitrary user setup (copy data and run script)
 COPY user-custom-data/ custom-data/


### PR DESCRIPTION
We installed these at some point in the past out of either copy-paste, or a need that no longer exists.
* `git` - user handles workspace sources on their own
* `wget` - we are not using it, we did at one point to pull `ros2.repos`
* `argcomplete` - there's no interactive portion to this container, there's no need for it
* `vcstool` - user handles workspace sources on their own


Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>