### PR TITLE
Use no-install-recommends for all apt install commands

### DIFF
--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -24,7 +24,7 @@ COPY qemu-user-static/ /usr/bin/
 RUN echo 'Etc/UTC' > /etc/timezone && \
     ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
         tzdata \
         locales \
     && rm -rf /var/lib/apt/lists/*
@@ -37,7 +37,7 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Add the ros apt repo
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
         gnupg2 \
         lsb-release \
     && rm -rf /var/lib/apt/lists/*
@@ -49,7 +49,7 @@ RUN echo "deb http://packages.ros.org/${ROS_VERSION}/ubuntu `lsb_release -cs` ma
     > /etc/apt/sources.list.d/${ROS_VERSION}-latest.list
 
 # ROS dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
       build-essential \
       cmake \
       python3-colcon-common-extensions \

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -38,6 +38,7 @@ ENV LC_ALL C.UTF-8
 
 # Add the ros apt repo
 RUN apt-get update && apt-get install --no-install-recommends -y \
+        dirmngr \
         gnupg2 \
         lsb-release \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We were seeing some flakiness in the end-to-end tests, failing to install package `humanity-icon-theme` occasionally. This was being pulled in as a "recommended" apt package below `colcon-common-extensions`, but is not needed.

See example failure https://github.com/ros-tooling/cross_compile/pull/155/checks?check_run_id=466189777

This has the added benefit of shaving some time ~1-3mins off each e2e run, and ~150MB off of the default e2e test container. 

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>