### PR TITLE
Raise exception when `docker run` fails

### DIFF
--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -95,12 +95,13 @@ class DockerClient:
         :raises docker.errors.ContainerError if container run has nonzero exit code
         :return None
         """
-        docker_volumes = {}
-        for src, dest in volumes.items():
-            docker_volumes[str(src)] = {
+        docker_volumes = {
+            str(src): {
                 'bind': dest,
                 'mode': 'rw',
             }
+            for src, dest in volumes.items()
+        }
         logs = self._client.containers.run(
             image=image_name,
             command=command,

--- a/test/test_docker_client.py
+++ b/test/test_docker_client.py
@@ -47,3 +47,9 @@ def test_parse_docker_build_output():
     ]
     with pytest.raises(docker.errors.BuildError):
         client._process_build_log(log_generator_with_errors)
+
+
+def test_fail_docker_run():
+    client = DockerClient()
+    with pytest.raises(docker.errors.ContainerError):
+        client.run_container('alpine', command='/bin/sh -c "exit 1"')

--- a/test/test_docker_client.py
+++ b/test/test_docker_client.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import platform
+
 import docker
 import pytest
 
@@ -49,6 +51,8 @@ def test_parse_docker_build_output():
         client._process_build_log(log_generator_with_errors)
 
 
+@pytest.mark.skipif(
+    platform.system() == 'Darwin', reason='CI environment cannot run docker on Mac')
 def test_fail_docker_run():
     client = DockerClient()
     with pytest.raises(docker.errors.ContainerError):


### PR DESCRIPTION
Before this change, if a command run in a container failed, it would print the error but keep running onto the next step. This makes the command fail by not detaching the container.

It also introduces the `command` parameter for easier testing and extensibility.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>