### PR TITLE
Separate rosdep collection from sysroot creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A tool to automate compiling ROS and ROS 2 workspaces to non-native architecture
 :construction: `ros_cross_compile` relies on running emulated builds
 using QEmu, #69 tracks progress toward enabling cross-compilation.
 
+
 ## Supported targets
 
 This tool supports compiling a workspace for all combinations of the following:
@@ -60,6 +61,18 @@ If you would like the latest nightly build, you can get it from Test PyPI
 pip3 install --index-url https://test.pypi.org/simple/ ros_cross_compile
 ```
 
+## How it works, high level
+
+1. Collect dependencies
+    1. Create a Docker image that has `rosdep`
+    1. Run the `rosdep` image against your target workspace to output a script that describes how to install its dependencies
+1. Create "sysroot image" that has everything needed for building target workspace
+    1. Use a base image for the target architecture
+    1. Install build tools (compilers, cmake, colcon, etc)
+    1. Run the dependency installer script collected in Step 1 (if dependency list hasn't changed since last run, this uses the Docker cache)
+1. Build
+    1. Runs the "sysroot image" using QEmu emulation
+    1. `colcon build`
 
 ## Usage
 
@@ -116,6 +129,33 @@ python3 -m ros_cross_compile \
   --rosdistro dashing
 ```
 
+### Custom rosdep script
+
+Your ROS application may need nonstandard rosdep rules.
+If so, you have the option to provide a script to be run before the `rosdep install` command collects keys.
+
+This script has access to the "Custom data directory", just like the "Custom setup script" following does, so if you need any extra files, they can be used in that way.
+
+Note that:
+1. Rosdeps are always collected in an Ubuntu Bionic container, so scripts must be compatible with that
+
+Here is an example script for an application that adds extra rosdep source lists
+
+```bash
+cp ./custom-data/rosdep-rules/raspicam-node.yaml /etc/ros/rosdep/custom-rules/raspicam-node.yaml
+echo "yaml file:/etc/ros/rosdep/custom-rules/raspicam-node.yaml" > /etc/ros/rosdep/sources.list.d/22-raspicam-node.list
+echo "yaml https://s3-us-west-2.amazonaws.com/rosdep/python.yaml" > /etc/ros/rosdep/sources.list.d/18-aws-python.list
+```
+
+Tool invocation for this example:
+
+```bash
+python3 -m ros_cross_compile \
+  --sysroot-path /absolute/path/to/directory/containing/sysroot
+  --arch aarch64 --os ubuntu \
+  --custom-rosdep-script /path/to/rosdep-script.sh \
+  --custom-data-dir /arbitrary/local/directory
+```
 
 ### Custom setup script
 
@@ -143,8 +183,8 @@ apt-get install -y pigpio
 
 ### Custom data directory
 
-Your custom setup script (see preceding) may need some data that is not accessible within the sysroot creation environment.
-For example, you need custom rosdep rules files to find and install your dependencies.
+Your custom setup or rosdep script (see preceding sections) may need some data that is not otherwise accessible.
+For example, you need to copy some precompiled vendor binaries to a specific location, or provide custom rosdep rules files.
 For this use case, you can use the option `--custom-data-dir` to point to an arbitrary path.
 The sysroot build copies this directory into the build environment, where it's available for use by your custom setup script at `./custom-data/`.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip3 install --index-url https://test.pypi.org/simple/ ros_cross_compile
     1. Create a Docker image that has `rosdep`
     1. Run the `rosdep` image against your target workspace to output a script that describes how to install its dependencies
 1. Create "sysroot image" that has everything needed for building target workspace
-    1. Use a base image for the target architecture
+    1. Use a base image for the target architecture (aarch64, armhf, ...)
     1. Install build tools (compilers, cmake, colcon, etc)
     1. Run the dependency installer script collected in Step 1 (if dependency list hasn't changed since last run, this uses the Docker cache)
 1. Build
@@ -134,7 +134,7 @@ python3 -m ros_cross_compile \
 Your ROS application may need nonstandard rosdep rules.
 If so, you have the option to provide a script to be run before the `rosdep install` command collects keys.
 
-This script has access to the "Custom data directory", just like the "Custom setup script" following does, so if you need any extra files, they can be used in that way.
+This script has access to the "Custom data directory" same as the "Custom setup script", see the following sections. If you need any extra files for setting up rosdep, they can be accessed via this custom data directory.
 
 Note that:
 1. Rosdeps are always collected in an Ubuntu Bionic container, so scripts must be compatible with that

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -1,0 +1,70 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from pathlib import Path
+from typing import Optional
+
+from ros_cross_compile.docker_client import DockerClient
+from ros_cross_compile.platform import Platform
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('Rosdep Gatherer')
+
+DEPENDENCY_SCRIPT_SUBPATH = Path('cc_internals') / 'install_rosdeps.sh'
+CUSTOM_SETUP = '/usercustom/rosdep_setup'
+
+
+def gather_rosdeps(
+    docker_client: DockerClient,
+    platform: Platform,
+    workspace: Path,
+    custom_script: Optional[Path] = None,
+    custom_data_dir: Optional[Path] = None,
+) -> None:
+    """
+    Run the rosdep Docker image, which outputs a script for dependency installation.
+
+    :param docker_client: Will be used to run the container
+    :param platform: The name of the image produced by `build_rosdep_image`
+    :param workspace: Absolute path to the colcon source workspace.
+    :param custom_script: Optional absolute path of a script that does custom setup for rosdep
+    :param custom_data_dir: Optional absolute path of a directory containing custom data for setup
+    :return None
+    """
+    image_name = 'ros_cross_compile:rosdep'
+    logger.info('Building rosdep collector image: %s', image_name)
+    docker_client.build_image(
+        dockerfile_name='rosdep.Dockerfile',
+        tag=image_name,
+    )
+
+    logger.info('Running rosdep collector image on workspace {}'.format(workspace))
+    volumes = {
+        workspace: '/ws',
+    }
+    if custom_script:
+        volumes[custom_script] = CUSTOM_SETUP
+    if custom_data_dir:
+        volumes[custom_data_dir] = '/usercustom/custom-data'
+
+    docker_client.run_container(
+        image_name=image_name,
+        environment={
+            'ROSDISTRO': platform.ros_distro,
+            'TARGET_OS': '{}:{}'.format(platform.os_name, platform.os_distro),
+            'OUT_PATH': str(DEPENDENCY_SCRIPT_SUBPATH),
+            'CUSTOM_SETUP': CUSTOM_SETUP,
+        },
+        volumes=volumes,
+    )

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -23,6 +23,7 @@ logger = logging.getLogger('Rosdep Gatherer')
 
 DEPENDENCY_SCRIPT_SUBPATH = Path('cc_internals') / 'install_rosdeps.sh'
 CUSTOM_SETUP = '/usercustom/rosdep_setup'
+CUSTOM_DATA = '/usercustom/custom-data'
 
 
 def gather_rosdeps(
@@ -56,7 +57,7 @@ def gather_rosdeps(
     if custom_script:
         volumes[custom_script] = CUSTOM_SETUP
     if custom_data_dir:
-        volumes[custom_data_dir] = '/usercustom/custom-data'
+        volumes[custom_data_dir] = CUSTOM_DATA
 
     docker_client.run_container(
         image_name=image_name,

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import logging
 from pathlib import Path
 from typing import Optional

--- a/ros_cross_compile/docker/gather_rosdeps.sh
+++ b/ros_cross_compile/docker/gather_rosdeps.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euxo pipefail
+
+if [ ! -d ./src ]; then
+  echo "No src/ directory found at $(pwd), did you remember to mount your workspace?"
+  exit 1
+fi
+
+if [ -f "${CUSTOM_SETUP}" ]; then
+  chmod +x "${CUSTOM_SETUP}"
+  pushd "$(dirname "${CUSTOM_SETUP}")"
+  "${CUSTOM_SETUP}"
+  popd
+fi
+
+mkdir -p "$(dirname "${OUT_PATH}")"
+
+rosdep update
+
+cat > "${OUT_PATH}" <<EOF
+#!/bin/bash
+set -euxo pipefail
+EOF
+
+rosdep install \
+    --os "${TARGET_OS}" \
+    --rosdistro "${ROSDISTRO}" \
+    --from-paths src/ \
+    --ignore-src \
+    --reinstall \
+    --default-yes \
+    --simulate \
+  >> "${OUT_PATH}"
+
+chmod +x "${OUT_PATH}"

--- a/ros_cross_compile/docker/rosdep.Dockerfile
+++ b/ros_cross_compile/docker/rosdep.Dockerfile
@@ -1,0 +1,22 @@
+# This Dockerfile describes a simple image with rosdep installed.
+# When `run`, it outputs a script for installing dependencies for a given workspace
+# Requirements:
+#  * mount a colcon workspace at /ws
+#  * see gather_rosdeps.sh for all-caps required input environment
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+      dirmngr \
+      gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-get update && apt-get install --no-install-recommends -y \
+      python-rosdep \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rosdep init
+COPY gather_rosdeps.sh /root/
+RUN mkdir -p /ws
+WORKDIR /ws
+ENTRYPOINT ["/root/gather_rosdeps.sh"]

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -1,14 +1,10 @@
-# This dockerfile takes ROS 1 or 2 source packages from ${ROS_WORKSPACE}/ros_ws/src
-# and builds them for the specified target platform.
-# It uses qemu user-mode static emulation libraries from ${ROS_WORKSPACE}/qemu-user-static/
-# to emulate the target platform.
-
-# Assumptions: ros_ws/src and qemu-user-static directories are present in ${ROS_WORKSPACE}.
+# This file describes an image that has everything necessary installed to build a target ROS workspace
+# It uses QEmu user-mode emulation to perform dependency installation and build
+# Assumptions: qemu-user-static directory is present in docker build context
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG ROS_WORKSPACE
 ARG ROS_VERSION
 ARG ROS_DISTRO
 ARG TARGET_ARCH

--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -33,18 +33,20 @@ class DockerClient:
         """
         self._client = docker.from_env()
         self._disable_cache = disable_cache
+        self._default_docker_dir = str(Path(__file__).parent / 'docker')
 
     def build_image(
         self,
-        dockerfile_dir: Path,
         dockerfile_name: str,
         tag: str,
+        dockerfile_dir: Optional[Path] = None,
         buildargs: Optional[Dict[str, str]] = None,
     ) -> None:
         """
         Build a Docker image from a Dockerfile.
 
-        :param dockerfile_dir: Absolute path to directory where Dockerfile can be found.
+        :param dockerfile_dir: Absolute path to directory where Dockerfile can be found,
+            defaults to the 'docker' directory in this package.
         :param dockerfile_name: The name of the Dockerfile to build.
         :param tag: What tag to give the created image.
         :param buildargs: Optional dictionary of str->str to set arguments for the build.
@@ -54,7 +56,7 @@ class DockerClient:
         # Use low-level API to expose logs for image building
         docker_api = docker.APIClient(base_url='unix://var/run/docker.sock')
         log_generator = docker_api.build(
-            path=str(dockerfile_dir),
+            path=str(dockerfile_dir) if dockerfile_dir else self._default_docker_dir,
             dockerfile=dockerfile_name,
             tag=tag,
             buildargs=buildargs,

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -200,7 +200,6 @@ class SysrootCreator:
             tag=image_tag,
             buildargs={
                 'BASE_IMAGE': self._platform.target_base_image,
-                'ROS_WORKSPACE': self._ros_workspace_relative_to_sysroot,
                 'ROS_VERSION': self._platform.ros_version,
                 'ROS_DISTRO': self._platform.ros_distro,
                 'TARGET_ARCH': self._platform.arch,

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -1,0 +1,162 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+import platform
+
+import docker
+import pytest
+
+from ros_cross_compile.dependencies import DEPENDENCY_SCRIPT_SUBPATH
+from ros_cross_compile.dependencies import gather_rosdeps
+from ros_cross_compile.docker_client import DockerClient
+from ros_cross_compile.platform import Platform
+
+NO_MAC_REASON = 'CI environment cannot install Docker on Mac OS hosts.'
+
+
+def is_mac():
+    return platform.system() == 'Darwin'
+
+
+def make_pkg_xml(contents):
+    return """<package format="3">
+  <name>dummy</name>
+  <version>0.0.0</version>
+  <description>Test package</description>
+  <maintainer email="example@example.com">Example</maintainer>
+  <license>None</license>
+  {}
+</package>
+""".format(contents)
+
+
+RCLCPP_PKG_XML = make_pkg_xml("""
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+""")
+
+CUSTOM_KEY_PKG_XML = make_pkg_xml("""
+  <depend>definitely_does_not_exist</depend>
+""")
+
+
+@pytest.mark.skipif(is_mac(), reason=NO_MAC_REASON)
+def test_dummy_ros2_pkg(tmpdir):
+    ws = Path(str(tmpdir))
+    pkg_xml = ws / 'src' / 'dummy' / 'package.xml'
+    out_script = ws / DEPENDENCY_SCRIPT_SUBPATH
+    pkg_xml.parent.mkdir(parents=True)
+    pkg_xml.write_text(RCLCPP_PKG_XML)
+
+    client = DockerClient()
+    platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
+
+    gather_rosdeps(client, platform, workspace=ws)
+    result = out_script.read_text().splitlines()
+    expected = [
+        '#!/bin/bash',
+        'set -euxo pipefail',
+        '#[apt] Installation commands:',
+        '  apt-get install -y ros-dashing-ament-cmake',
+        '  apt-get install -y ros-dashing-rclcpp',
+    ]
+    assert result == expected, 'Rosdep output did not meet expectations.'
+
+
+@pytest.mark.skipif(is_mac(), reason=NO_MAC_REASON)
+def test_rosdep_bad_key(tmpdir):
+    ws = Path(str(tmpdir))
+    pkg_xml = Path(ws) / 'src' / 'dummy' / 'package.xml'
+    pkg_xml.parent.mkdir(parents=True)
+    pkg_xml.write_text(CUSTOM_KEY_PKG_XML)
+    client = DockerClient()
+    platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
+    with pytest.raises(docker.errors.ContainerError):
+        gather_rosdeps(client, platform, workspace=ws)
+
+
+@pytest.mark.skipif(is_mac(), reason=NO_MAC_REASON)
+def test_custom_rosdep_no_data_dir(tmpdir):
+    script_contents = """
+cat > /test_rules.yaml <<EOF
+definitely_does_not_exist:
+  ubuntu:
+    bionic: [successful_test]
+EOF
+echo "yaml file:/test_rules.yaml" > /etc/ros/rosdep/sources.list.d/22-test-rules.list
+"""
+    ws = Path(str(tmpdir))
+    pkg_xml = Path(ws) / 'src' / 'dummy' / 'package.xml'
+    pkg_xml.parent.mkdir(parents=True)
+    pkg_xml.write_text(CUSTOM_KEY_PKG_XML)
+    client = DockerClient()
+    platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
+
+    rosdep_setup = ws / 'rosdep_setup.sh'
+    rosdep_setup.write_text(script_contents)
+
+    gather_rosdeps(client, platform, workspace=ws, custom_script=rosdep_setup)
+    out_script = ws / DEPENDENCY_SCRIPT_SUBPATH
+    result = out_script.read_text().splitlines()
+    expected = [
+        '#!/bin/bash',
+        'set -euxo pipefail',
+        '#[apt] Installation commands:',
+        '  apt-get install -y successful_test',
+    ]
+    assert result == expected, 'Rosdep output did not meet expectations.'
+
+
+@pytest.mark.skipif(is_mac(), reason=NO_MAC_REASON)
+def test_custom_rosdep_with_data_dir(tmpdir):
+
+    rule_contents = """
+definitely_does_not_exist:
+  ubuntu:
+    bionic: [successful_test]
+"""
+
+    script_contents = """
+#!/bin/bash
+set -euxo
+cp ./custom-data/test_rules.yaml /test_rules.yaml
+echo "yaml file:/test_rules.yaml" > /etc/ros/rosdep/sources.list.d/22-test-rules.list
+"""
+    ws = Path(str(tmpdir))
+    pkg_xml = Path(ws) / 'src' / 'dummy' / 'package.xml'
+    pkg_xml.parent.mkdir(parents=True)
+    pkg_xml.write_text(CUSTOM_KEY_PKG_XML)
+    client = DockerClient()
+    platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
+
+    rosdep_setup = ws / 'rosdep_setup.sh'
+    rosdep_setup.write_text(script_contents)
+
+    data_dir = ws / 'custom_data'
+    data_file = data_dir / 'test_rules.yaml'
+    data_file.parent.mkdir(parents=True)
+    data_file.write_text(rule_contents)
+
+    gather_rosdeps(
+        client, platform, workspace=ws, custom_script=rosdep_setup, custom_data_dir=data_dir)
+
+    out_script = ws / DEPENDENCY_SCRIPT_SUBPATH
+    result = out_script.read_text().splitlines()
+    expected = [
+        '#!/bin/bash',
+        'set -euxo pipefail',
+        '#[apt] Installation commands:',
+        '  apt-get install -y successful_test',
+    ]
+    assert result == expected, 'Rosdep output did not meet expectations.'


### PR DESCRIPTION
Fixes https://github.com/ros-tooling/cross_compile/issues/106

Creates a separate container, that runs natively, and outputs a script for installing workspace dependencies.

If the script has not changed (no dependencies have changed), the docker cache is used and the build can begin immediately. This makes the tool much more usable by skipping the very slow rosdep installation step whenever a source file is changed.

Note that docker-based tests are not run on our macOS Github Action hosts, because they will not install docker on those due to licensing issues.