### PR TITLE
Reenable -ux bash args in build workspace script

### DIFF
--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
-# No -u because setup.bash for ROS has unset variables
-# No -x because it prints all of setup.bash steps, which are numerous and noisy
-set -eo pipefail
+set -euxo pipefail
 
-[ "${ROS_DISTRO}" ] || (echo "ROSDISTRO var unset" && exit 1)
-[ "${TARGET_ARCH}" ] || (echo "TARGET_ARCH var unset" && exit 1)
-[ "${OWNER_USER}" ] || (echo "OWNER_USER var unset" && exit 1)
-
-# shellcheck source=/dev/null
-source /opt/ros/"${ROS_DISTRO}"/setup.bash
+set +ux
+source "$ros_dir"/setup.bash
+set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \
   --build-base build_"${TARGET_ARCH}" \
   --install-base install_"${TARGET_ARCH}"

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 set +ux
 # shellcheck source=/dev/null
-source "$ros_dir"/setup.bash
+source /opt/ros/"${ROS_DISTRO}"/setup.bash
 set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \
   --build-base build_"${TARGET_ARCH}" \

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -2,6 +2,7 @@
 set -euxo pipefail
 
 set +ux
+# shellcheck source=/dev/null
 source "$ros_dir"/setup.bash
 set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \


### PR DESCRIPTION
This way the script can be verbose, just disable the checks around the sourced `setup.bash` script to suppress its noisiness and unset variables.