### PR TITLE
Remove arguments from sysroot image

### DIFF
--- a/ros_cross_compile/builders.py
+++ b/ros_cross_compile/builders.py
@@ -16,24 +16,30 @@ import os
 from pathlib import Path
 
 from ros_cross_compile.docker_client import DockerClient
+from ros_cross_compile.platform import Platform
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
 def run_emulated_docker_build(
-    docker_client: DockerClient, image_tag: str, workspace_path: Path
+    docker_client: DockerClient,
+    platform: Platform,
+    workspace_path: Path
 ) -> None:
     """
     Spin up a sysroot docker container and run an emulated build inside.
 
-    :param image_tag: Docker image that contains all preinstalled dependencies for workspace.
+    :param docker_client: Preconfigured to run Docker images.
+    :param platform: Information about the target platform.
     :param workspace: Absolute path to the user's source workspace.
     """
     docker_client.run_container(
-        image_name=image_tag,
+        image_name=platform.sysroot_image_tag,
         environment={
             'OWNER_USER': str(os.getuid()),
+            'ROS_DISTRO': platform.ros_distro,
+            'TARGET_ARCH': platform.arch,
         },
         volumes={
             workspace_path: '/ros_ws',

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
-# No -u because setup.bash for ROS has unset variables
-# No -x because it prints all of setup.bash steps, which are numerous and noisy
-set -eo pipefail
+set -euxo pipefail
 
-[ "${ROS_DISTRO}" ] || (echo "ROSDISTRO var unset" && exit 1)
-[ "${TARGET_ARCH}" ] || (echo "TARGET_ARCH var unset" && exit 1)
-[ "${OWNER_USER}" ] || (echo "OWNER_USER var unset" && exit 1)
-
-# shellcheck source=/dev/null
-source /opt/ros/"${ROS_DISTRO}"/setup.bash
+set +ux
+source "$ros_dir"/setup.bash
+set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \
   --build-base build_"${TARGET_ARCH}" \
   --install-base install_"${TARGET_ARCH}"

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euxo pipefail
 
+mkdir -p /opt/ros/"${ROS_DISTRO}"
+touch /opt/ros/"${ROS_DISTRO}"/setup.bash
+
 set +ux
 # shellcheck source=/dev/null
 source /opt/ros/"${ROS_DISTRO}"/setup.bash

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 set +ux
 # shellcheck source=/dev/null
-source "$ros_dir"/setup.bash
+source /opt/ros/"${ROS_DISTRO}"/setup.bash
 set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \
   --build-base build_"${TARGET_ARCH}" \

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -2,6 +2,7 @@
 set -euxo pipefail
 
 set +ux
+# shellcheck source=/dev/null
 source "$ros_dir"/setup.bash
 set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -6,11 +6,6 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 ARG ROS_VERSION
-ARG ROS_DISTRO
-ARG TARGET_ARCH
-
-ENV ROS_DISTRO=${ROS_DISTRO}
-ENV TARGET_ARCH=${TARGET_ARCH}
 
 SHELL ["/bin/bash", "-c"]
 
@@ -102,9 +97,6 @@ RUN apt-get update && \
 COPY mixins/ mixins/
 RUN colcon mixin add cc_mixin file://$(pwd)/mixins/index.yaml && colcon mixin update cc_mixin
 # In case the workspace did not actually install any dependencies, add these for uniformity
-RUN mkdir -p /opt/ros/${ROS_DISTRO} && \
-    touch /opt/ros/${ROS_DISTRO}/setup.sh && \
-    touch /opt/ros/${ROS_DISTRO}/setup.bash
 COPY build_workspace.sh /root
 WORKDIR /ros_ws
 ENTRYPOINT ["/root/build_workspace.sh"]

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -149,7 +149,7 @@ def main():
         custom_data_dir=_path_if(args.custom_data_dir))
     shutil.copy(str(output_rosdep_script), str(sysroot_dir))
     sysroot_creator.create_workspace_sysroot_image(docker_client)
-    run_emulated_docker_build(docker_client, platform.sysroot_image_tag, ros_workspace_dir)
+    run_emulated_docker_build(docker_client, platform, ros_workspace_dir)
 
 
 if __name__ == '__main__':

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -201,8 +201,6 @@ class SysrootCreator:
             buildargs={
                 'BASE_IMAGE': self._platform.target_base_image,
                 'ROS_VERSION': self._platform.ros_version,
-                'ROS_DISTRO': self._platform.ros_distro,
-                'TARGET_ARCH': self._platform.arch,
             }
         )
         logger.info('Successfully created sysroot docker image: %s', image_tag)

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -15,10 +15,12 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from ros_cross_compile.builders import run_emulated_docker_build
+from ros_cross_compile.platform import Platform
 
 
 def test_emulated_docker_build():
     # Very simple smoke test to validate that all internal syntax is correct
     mock_docker_client = Mock()
-    run_emulated_docker_build(mock_docker_client, 'image_tag', Path('dummy_path'))
+    platform = Platform('aarch64', 'ubuntu', 'eloquent')
+    run_emulated_docker_build(mock_docker_client, platform, Path('dummy_path'))
     assert mock_docker_client.run_container.call_count == 1


### PR DESCRIPTION
By removing the arguments and early-set environment variables, we increase docker cache reuse.

The long term goal is to store Docker images on a registry so users can pull rather than recreate common base images.

Removing these arguments and environment variables makes more of the base builder image common. Now the matrix is just [OS, arch].

Another benefit is that the arguments to the `build_workspace` script all must be provided by the caller, which makes everything a bit more explicit.