### PR TITLE
Point the tool at any workspace, don't require specific setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install -y qemu-user-static
+      if: matrix.os == 'ubuntu-18.04'
     - name: Install Tox for testing
       run: pip install tox
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -76,58 +76,17 @@ pip3 install --index-url https://test.pypi.org/simple/ ros_cross_compile
 
 ## Usage
 
-This script requires a `sysroot` directory containing the ROS 2 workspace, and
-the toolchain.
+This package installs the `ros_cross_compile` command.
+The command's first argument is the path to your ROS workspace.
 
-The following instructions explain how to create a `sysroot` directory.
-
-#### Create the directory structure
+Here is a simple invocation for a standard workflow.
 
 ```bash
-mkdir -p sysroot/qemu-user-static
-mkdir -p sysroot/ros_ws/src
+ros_cross_compile /path/to/my/workspace --arch aarch64 --os ubuntu --rosdistro dashing
 ```
 
-#### Copy the QEMU Binaries
-
-```bash
-cp /usr/bin/qemu-*-static sysroot/qemu-user-static/
-```
-
-
-#### Prepare `ros_ws`
-Use [ROS](http://wiki.ros.org/ROS/Installation) or [ROS 2](https://index.ros.org/doc/ros2/Installation/) source installation guide to get the ROS repositories needed to cross compile.
-
-Once you have the desired sources, copy them in the `sysroot` to use with the tool.
-```bash
-# Copy ros sources into the sysroot directory
-cp -r <full_path_to_your_ros_ws>/src sysroot/ros_ws
-```
-
-
-#### Run the cross compilation script
-
-In the end your `sysroot` directory should look like this:
-
-```bash
-sysroot/
- +-- qemu-user-static/
- |   +-- qemu-*-static
- +-- ros_ws/
-     +-- src/
-          |-- (ros packages)
-          +-- ...
-```
-
-Then run the tool:
-
-```bash
-python3 -m ros_cross_compile \
-  --sysroot-path /absolute/path/to/sysroot \
-  --arch aarch64 \
-  --os ubuntu
-  --rosdistro dashing
-```
+For information on all available options, run `ros_cross_compile -h`.
+See the following sections for information on the more complex options.
 
 ### Custom rosdep script
 
@@ -150,9 +109,7 @@ echo "yaml https://s3-us-west-2.amazonaws.com/rosdep/python.yaml" > /etc/ros/ros
 Tool invocation for this example:
 
 ```bash
-python3 -m ros_cross_compile \
-  --sysroot-path /absolute/path/to/directory/containing/sysroot
-  --arch aarch64 --os ubuntu \
+ros_cross_compile /path/to/my/workspace --arch aarch64 --os ubuntu \
   --custom-rosdep-script /path/to/rosdep-script.sh \
   --custom-data-dir /arbitrary/local/directory
 ```
@@ -207,9 +164,7 @@ cat custom-data/something.txt
 Tool invocation:
 
 ```bash
-python3 -m ros_cross_compile \
-  --sysroot-path /absolute/path/to/directory/containing/sysroot
-  --arch aarch64 --os ubuntu \
+python3 -m ros_cross_compile /path/to/my/workspace --arch aarch64 --os ubuntu \
   --custom-setup-script /path/to/custom-setup.sh \
   --custom-data-dir /arbitrary/local/directory
 ```
@@ -228,7 +183,7 @@ You can generalize this workflow to any `.repos` file for your project.
 
 NOTE: this tutorial assumes a Debian-based (including Ubuntu) Linux distribution as the host platform.
 
-### Creating a cross-compilation workspace
+### Creating a simple source workspace
 
 1. Create a directory for your workspace
     * `mkdir cross_compile_ws`
@@ -242,28 +197,17 @@ NOTE: this tutorial assumes a Debian-based (including Ubuntu) Linux distribution
         url: https://github.com/ros-tooling/file_talker.git
         version: master
     ```
-1. Set up the sysroot environment for the cross-compiler to use
-    * `mkdir -p sysroot/qemu-user-static/`
-    * `mkdir -p sysroot/ros_ws/src/`
-    * `cp /usr/bin/qemu-*-static sysroot/qemu-user-static`
-    * `vcs import ros_ws/src < file_talker.repos`
+1. Check out the sources to build
+    * `mkdir -p src`
+    * `vcs import src < file_talker.repos`
 
 ### Running the cross-compilation
 
 ```bash
-python3 -m ros_cross_compile \
-  --sysroot-path $(pwd) \
-  --rosdistro dashing \
-  --arch aarch64 \
-  --os ubuntu
+ros_cross_compile $(pwd) --rosdistro dashing --arch aarch64 --os ubuntu
 ```
 
 Here is a detailed look at the arguments passed to the script:
-
-* `--sysroot-path $(pwd)`
-
-Point the `ros_cross_compile` tool to the absolute path of the directory containing the `sysroot` directory created earlier.
-You could run the tool from any directory, but in this case the current working directory contains `sysroot`, hence `$(pwd)`
 
 * `--rosdistro dashing`
 
@@ -285,25 +229,24 @@ In this case for ROS 2 Dashing - 18.04 Bionic Beaver.
 Run the following command
 
 ```bash
-ls sysroot/ros_ws/
+ls cross_compile_ws
 ```
 
 If the build succeeded, the directory looks like this:
 
 ```
-ros_ws/
-+-- src/
-    |-- file_talker
-+-- install_aarch64/
-    |-- ...
+src/
+|-- file_talker/
+|-- install_aarch64/
+|-- build_aarch64/
 ```
 
 The created directory `install_aarch64` is the installation of your ROS workspace for your target architecture.
 You can verify this:
 
 ```bash
-$ file ros_ws/install_aarch64/lib/file_talker/file_talker                                                               0s
-ros_ws/install_aarch64/lib/file_talker/file_talker: ELF 64-bit LSB shared object, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-, for GNU/Linux 3.7.0, BuildID[sha1]=02ede8a648dfa6b5b30c03d54c6d87fd9151389e, not stripped
+$ file cross_compile_ws/install_aarch64/lib/file_talker/file_talker                                                               0s
+cross_compile_ws/install_aarch64/lib/file_talker/file_talker: ELF 64-bit LSB shared object, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-, for GNU/Linux 3.7.0, BuildID[sha1]=02ede8a648dfa6b5b30c03d54c6d87fd9151389e, not stripped
 ```
 
 ### Using the build on a target platform

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ cat custom-data/something.txt
 Tool invocation:
 
 ```bash
-python3 -m ros_cross_compile /path/to/my/workspace --arch aarch64 --os ubuntu \
+ros_cross_compile /path/to/my/workspace --arch aarch64 --os ubuntu \
   --custom-setup-script /path/to/custom-setup.sh \
   --custom-data-dir /arbitrary/local/directory
 ```

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -44,6 +45,8 @@ def gather_rosdeps(
     :param custom_data_dir: Optional absolute path of a directory containing custom data for setup
     :return None
     """
+    out_path = Path('cc_internals') / str(platform) / 'install_rosdeps.sh'
+
     image_name = 'ros_cross_compile:rosdep'
     logger.info('Building rosdep collector image: %s', image_name)
     docker_client.build_image(
@@ -63,9 +66,10 @@ def gather_rosdeps(
     docker_client.run_container(
         image_name=image_name,
         environment={
+            'OWNER_USER': str(os.getuid()),
             'ROSDISTRO': platform.ros_distro,
             'TARGET_OS': '{}:{}'.format(platform.os_name, platform.os_distro),
-            'OUT_PATH': str(DEPENDENCY_SCRIPT_SUBPATH),
+            'OUT_PATH': str(out_path),
             'CUSTOM_SETUP': CUSTOM_SETUP,
         },
         volumes=volumes,

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -29,6 +29,11 @@ CUSTOM_SETUP = '/usercustom/rosdep_setup'
 CUSTOM_DATA = '/usercustom/custom-data'
 
 
+def rosdep_install_script(platform: Platform) -> Path:
+    """Construct relative path of the script that installs rosdeps into the sysroot image."""
+    return build_internals_dir(platform) / 'install_rosdeps.sh'
+
+
 def gather_rosdeps(
     docker_client: DockerClient,
     platform: Platform,
@@ -46,7 +51,7 @@ def gather_rosdeps(
     :param custom_data_dir: Optional absolute path of a directory containing custom data for setup
     :return None
     """
-    out_path = build_internals_dir(platform) / 'install_rosdeps.sh'
+    out_path = rosdep_install_script(platform)
 
     image_name = 'ros_cross_compile:rosdep'
     logger.info('Building rosdep collector image: %s', image_name)

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -19,11 +19,12 @@ from typing import Optional
 
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.platform import Platform
+from ros_cross_compile.sysroot_creator import build_internals_dir
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('Rosdep Gatherer')
 
-DEPENDENCY_SCRIPT_SUBPATH = Path('cc_internals') / 'install_rosdeps.sh'
+
 CUSTOM_SETUP = '/usercustom/rosdep_setup'
 CUSTOM_DATA = '/usercustom/custom-data'
 
@@ -45,7 +46,7 @@ def gather_rosdeps(
     :param custom_data_dir: Optional absolute path of a directory containing custom data for setup
     :return None
     """
-    out_path = Path('cc_internals') / str(platform) / 'install_rosdeps.sh'
+    out_path = build_internals_dir(platform) / 'install_rosdeps.sh'
 
     image_name = 'ros_cross_compile:rosdep'
     logger.info('Building rosdep collector image: %s', image_name)

--- a/ros_cross_compile/docker/gather_rosdeps.sh
+++ b/ros_cross_compile/docker/gather_rosdeps.sh
@@ -13,7 +13,8 @@ if [ -f "${CUSTOM_SETUP}" ]; then
   popd
 fi
 
-mkdir -p "$(dirname "${OUT_PATH}")"
+out_dir=$(dirname "${OUT_PATH}")
+mkdir -p "${out_dir}"
 
 rosdep update
 
@@ -33,3 +34,4 @@ rosdep install \
   >> "${OUT_PATH}"
 
 chmod +x "${OUT_PATH}"
+chown -R "${OWNER_USER}" "${out_dir}"

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -9,7 +9,7 @@ ARG ROS_VERSION
 
 SHELL ["/bin/bash", "-c"]
 
-COPY qemu-user-static/ /usr/bin/
+COPY bin/* /usr/bin/
 
 # Set timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \

--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('Docker Client')
 class DockerClient:
     """Simplified Docker API for this package's usage patterns."""
 
-    def __init__(self, disable_cache: bool = False):
+    def __init__(self, disable_cache: bool = False, default_docker_dir: Optional[Path] = None):
         """
         Construct the DockerClient.
 
@@ -33,7 +33,7 @@ class DockerClient:
         """
         self._client = docker.from_env()
         self._disable_cache = disable_cache
-        self._default_docker_dir = str(Path(__file__).parent / 'docker')
+        self._default_docker_dir = str(default_docker_dir or Path(__file__).parent / 'docker')
 
     def build_image(
         self,

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import getpass
+from typing import NamedTuple
 from typing import Optional
 
+ArchNameMapping = NamedTuple('ArchNameMapping', [('docker', str), ('qemu', str)])
+
+
 # NOTE: when changing any following values, update README.md Supported Targets section
-ARCHITECTURE_DOCKER_MAP = {
-    'armhf': 'arm32v7',
-    'aarch64': 'arm64v8',
+ARCHITECTURE_NAME_MAP = {
+    'armhf': ArchNameMapping(docker='arm32v7', qemu='arm'),
+    'aarch64': ArchNameMapping(docker='arm64v8', qemu='aarch64'),
 }
-SUPPORTED_ARCHITECTURES = tuple(ARCHITECTURE_DOCKER_MAP.keys())
+SUPPORTED_ARCHITECTURES = tuple(ARCHITECTURE_NAME_MAP.keys())
 
 SUPPORTED_ROS2_DISTROS = ('dashing', 'eloquent')
 SUPPORTED_ROS_DISTROS = ('kinetic', 'melodic')
@@ -64,7 +68,7 @@ class Platform:
         self._os_name = os_name
 
         try:
-            docker_org = ARCHITECTURE_DOCKER_MAP[arch]
+            docker_org = ARCHITECTURE_NAME_MAP[arch].docker
         except KeyError:
             raise ValueError('Unknown target architecture "{}" specified'.format(arch))
 
@@ -89,6 +93,10 @@ class Platform:
     @property
     def arch(self):
         return self._arch
+
+    @property
+    def qemu_arch(self):
+        return ARCHITECTURE_NAME_MAP[self.arch].qemu
 
     @property
     def ros_distro(self):

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -111,9 +111,9 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     return parser.parse_args(args)
 
 
-def main():
-    """Start the cross-compilation workflow."""
-    args = parse_args(sys.argv[1:])
+def cross_compile_pipeline(
+    args: argparse.Namespace,
+):
     platform = Platform(args.arch, args.os, args.rosdistro, args.sysroot_base_image)
 
     ros_workspace_dir = Path(args.ros_workspace)
@@ -136,6 +136,12 @@ def main():
         custom_data_dir=custom_data_dir)
     create_workspace_sysroot_image(docker_client, platform)
     run_emulated_docker_build(docker_client, platform, ros_workspace_dir)
+
+
+def main():
+    """Start the cross-compilation workflow."""
+    args = parse_args(sys.argv[1:])
+    cross_compile_pipeline(args)
 
 
 if __name__ == '__main__':

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -15,6 +15,7 @@
 from distutils.dir_util import copy_tree
 import logging
 from pathlib import Path
+from platform import system
 import shutil
 from typing import Optional
 
@@ -75,7 +76,7 @@ def prepare_docker_build_environment(
         custom_setup_dest.touch()
 
     # OSX performs emulation automatically
-    if platform.system() != 'Darwin':
+    if system() != 'Darwin':
         emulator_path = Path('/') / 'usr' / 'bin' / 'qemu-{}-static'.format(platform.qemu_arch)
         if not emulator_path.is_file():
             raise RuntimeError('Could not find the expected QEmu emulator binary "{}"'.format(

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -74,10 +74,12 @@ def prepare_docker_build_environment(
     else:
         custom_setup_dest.touch()
 
-    emulator_path = Path('/') / 'usr' / 'bin' / 'qemu-{}-static'.format(platform.qemu_arch)
-    if not emulator_path.is_file():
-        raise RuntimeError('Could not find the expected QEmu emulator binary "{}"'.format(
-            emulator_path))
+    # OSX performs emulation automatically
+    if platform.system() != 'Darwin':
+        emulator_path = Path('/') / 'usr' / 'bin' / 'qemu-{}-static'.format(platform.qemu_arch)
+        if not emulator_path.is_file():
+            raise RuntimeError('Could not find the expected QEmu emulator binary "{}"'.format(
+                emulator_path))
 
     bin_dir = docker_build_dir / 'bin'
     bin_dir.mkdir(parents=True)

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -12,195 +12,93 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from distutils.dir_util import copy_tree
 import logging
-import os
 from pathlib import Path
 import shutil
-from string import Template
 from typing import Optional
 
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.platform import Platform
 
-ROS_WS_DIR_ERROR_STRING = Template(
-    """"$ros_ws" does not exist in the sysroot directory. Make """
-    """sure you copy your packages as "$ros_ws/src" into the """
-    """"sysroot" directory."""
-    )
-QEMU_DIR_ERROR_STRING = Template(
-    """"$qemu_dir" does not exist in the sysroot directory. Make """
-    """sure you copy the binaries from "/usr/bin/qemu-*" into the """
-    """sysroot directory."""
-)
-
-QEMU_EMPTY_ERROR_STRING = Template(
-    """"$qemu_dir" is empty. Make sure you copy the binaries from """
-    """"/usr/bin/qemu-*" into "$qemu_dir".""")
-
-COPY_WS_FILE_ERROR_STRING = Template(
-    """Unable to copy the "$filename" file. Make sure you """
-    """have write permissions to the sysroot directory."""
-)
-
-SYSROOT_NOT_FOUND_ERROR_STRING = Template(
-    """Sysroot directory not found at "$sysroot_dir". Make """
-    """sure you specify the full path to the directory containing "sysroot"."""
-)
-
-SYSROOT_DIR_NAME = 'sysroot'  # type: str
-QEMU_DIR_NAME = 'qemu-user-static'  # type: str
-ROS_DOCKERFILE_NAME = 'sysroot.Dockerfile'  # type: str
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-
-def _replace_tree(src: Path, dest: Path) -> None:
-    """Delete dest and copy the directory src to that location."""
-    shutil.rmtree(str(dest), ignore_errors=True)  # it may or may not exist already
-    shutil.copytree(str(src), str(dest))
+INTERNALS_DIR = Path('cc_internals')
 
 
-def _ensure_exists(src: Path) -> None:
-    """Check that a path exists and raise a FileNotFoundError if not."""
-    if not src.exists():
-        raise FileNotFoundError(COPY_WS_FILE_ERROR_STRING.substitute(filename=src))
+def _copytree(src: Path, dest: Path) -> None:
+    copy_tree(str(src), str(dest))
 
 
-class SysrootCreator:
+def _copyfile(src: Path, dest: Path) -> None:
+    shutil.copy(str(src), str(dest))
+
+
+def prepare_docker_build_environment(
+    platform: Platform,
+    ros_workspace: Path,
+    custom_setup_script: Optional[Path],
+    custom_data_dir: Optional[Path],
+) -> Path:
     """
-    Create a sysroot with all dependencies for a workspace.
+    Prepare the directory for the sysroot.Docker build context.
 
-    Uses Docker to install dependencies on an emulated target, which produces
-    a Docker image with everything installed.
+    :param platform Information about the target platform
+    :param ros_workspace Location of the ROS source workspace
+    :param install_rosdep_script Path to the generated script that installs rosdeps in the sysroot
+    :param custom_setup_script Optional arbitrary script
+    :param custom_data_dir Optional arbitrary directory for use by custom_setup_script
+    :return The directory that was created.
     """
+    package_dir = Path(__file__).parent
+    docker_build_dir = ros_workspace / INTERNALS_DIR / str(platform)
+    docker_build_dir.mkdir(parents=True)
 
-    def __init__(
-      self,
-      cc_root_dir: str,
-      ros_workspace_dir: str,
-      platform: Platform,
-      custom_setup_script_path: Optional[str] = None,
-      custom_data_dir: Optional[str] = None,
-    ) -> None:
-        """
-        Construct a SysrootCreator object building ROS 2 Docker container.
+    _copytree(package_dir / 'docker', docker_build_dir)
+    _copytree(package_dir / 'mixins', docker_build_dir / 'mixins')
+    custom_data_dest = docker_build_dir / 'user-custom-data'
+    custom_setup_dest = docker_build_dir / 'user-custom-setup'
+    if custom_data_dir:
+        _copytree(custom_data_dir, custom_data_dest)
+    else:
+        custom_data_dest.mkdir()
+    if custom_setup_script:
+        _copyfile(custom_setup_script, custom_setup_dest)
+    else:
+        custom_setup_dest.touch()
 
-        :param cc_root_dir: The directory containing the 'sysroot' directory
-                            with the ROS2 workspace and QEMU binaries.
-        :param ros_workspace_dir: The name of the directory containing the
-                                  ROS2 packages (inside a 'src' directory).
-        :param platform: A custom object used to specify the the platform for
-                         cross-compilation.
-        :param custom_setup_script_path: Optional path to a custom setup script
-                                         to run arbitrary commands
-        :param custom_data_dir: Optional path to a custom directory of data that
-                                `custom_setup_script` can utilize
-        """
-        if not isinstance(cc_root_dir, str):
-            raise TypeError('Argument `cc_root_dir` must be of type string.')
-        if not isinstance(ros_workspace_dir, str):
-            raise TypeError(
-                'Argument `ros_workspace_dir` must be of type string.')
-        if not isinstance(platform, Platform):
-            raise TypeError('Argument `platform` must be of type Platform.')
+    bin_dir = docker_build_dir / 'bin'
+    bin_dir.mkdir(parents=True)
+    emulator_path = Path('/') / 'usr' / 'bin' / 'qemu-{}-static'.format(platform.qemu_arch)
+    if not emulator_path.is_file():
+        raise RuntimeError('Could not find the expected QEmu emulator binary "{}"'.format(
+            emulator_path))
+    _copyfile(emulator_path, bin_dir)
 
-        workspace_root = Path(cc_root_dir).resolve()
-        self._target_sysroot = workspace_root / SYSROOT_DIR_NAME
-        self._ros_workspace_relative_to_sysroot = ros_workspace_dir
-        self._ros_workspace_dir = self._target_sysroot / self._ros_workspace_relative_to_sysroot
-        self._qemu_directory = self._target_sysroot / QEMU_DIR_NAME
-        self._final_dockerfile_path = (
-            self._target_sysroot / ROS_DOCKERFILE_NAME)
-        self._system_setup_script_path = Path()
-        self._build_setup_script_path = Path()
-        self._platform = platform
-        self._setup_sysroot_dir(custom_setup_script_path, custom_data_dir)
+    return docker_build_dir
 
-    def get_system_setup_script_path(self) -> Path:
-        """Return the path to the system setup script."""
-        return self._system_setup_script_path
 
-    def get_build_setup_script_path(self) -> Path:
-        """Return the path to the build setup script."""
-        return self._build_setup_script_path
+def create_workspace_sysroot_image(
+    docker_client: DockerClient,
+    platform: Platform,
+) -> None:
+    """
+    Create the target platform sysroot image.
 
-    def _setup_sysroot_dir(self, custom_script: Optional[str], custom_data: Optional[str]) -> None:
-        """
-        Check to make sure the sysroot directory is setup correctly.
+    :param docker_client Docker client to use for building
+    :param platform Information about the target platform
+    :param build_context Directory containing all assets needed by sysroot.Dockerfile
+    """
+    image_tag = platform.sysroot_image_tag
 
-        Raises FileNotFoundError if any of the components necessary for
-        cross compilation are missing. Copies the Dockerfile to the
-        'sysroot' directory in order to copy the assets to it.
-        See https://docs.docker.com/engine/reference/builder/#copy
-        """
-        if not self._target_sysroot.exists():
-            raise FileNotFoundError(SYSROOT_NOT_FOUND_ERROR_STRING.substitute(
-                sysroot_dir=self._target_sysroot))
-        logger.debug('Sysroot directory exists.')
-
-        if not self._ros_workspace_dir.exists():
-            raise FileNotFoundError(ROS_WS_DIR_ERROR_STRING.substitute(
-                ros_ws=self._ros_workspace_dir))
-        logger.debug('ROS workspace exists.')
-
-        if not self._qemu_directory.exists():
-            raise FileNotFoundError(
-                QEMU_DIR_ERROR_STRING.substitute(qemu_dir=QEMU_DIR_NAME))
-        if not os.listdir(str(self._qemu_directory.absolute())):
-            raise FileNotFoundError(
-                QEMU_EMPTY_ERROR_STRING.substitute(qemu_dir=QEMU_DIR_NAME))
-        logger.debug('QEMU binaries exist')
-
-        package_path = Path(__file__).parent
-        dockerfile_src = str(package_path / 'docker' / ROS_DOCKERFILE_NAME)
-        shutil.copy(dockerfile_src, str(self._target_sysroot))
-        _ensure_exists(self._final_dockerfile_path)
-        logger.debug('Copied Dockerfile')
-
-        build_script_src = str(package_path / 'docker' / 'build_workspace.sh')
-        shutil.copy(build_script_src, str(self._target_sysroot))
-        _ensure_exists(self._target_sysroot / 'build_workspace.sh')
-        logger.debug('Copied builder script')
-
-        custom_data_dest = str(self._target_sysroot / 'user-custom-data')
-        shutil.rmtree(
-            custom_data_dest, ignore_errors=True
-        )  # should not be there unless explicitly specified
-        if custom_data:
-            shutil.copytree(custom_data, custom_data_dest)
-            logger.debug('Custom data dir provided - copied')
-        else:
-            os.makedirs(custom_data_dest)
-            logger.debug('No custom data dir provided - touched empty dir')
-
-        mixins_src = package_path / 'mixins'
-        mixins_dest = self._target_sysroot / 'mixins'
-        _replace_tree(mixins_src, mixins_dest)
-        if not mixins_dest.exists():
-            raise FileNotFoundError('Mixins not properly copied to build context')
-        logger.debug('Copied mixins')
-
-        custom_script_dest = str(self._target_sysroot / 'user-custom-setup')
-        if custom_script:
-            shutil.copy(custom_script, custom_script_dest)
-            logger.debug('Custom script provided - copied')
-        else:
-            with open(custom_script_dest, 'w') as custom_script_file:
-                custom_script_file.write('#!/bin/sh\necho "No custom setup"\n')
-            logger.debug('No custom script provided - created empty script')
-
-    def create_workspace_sysroot_image(self, docker_client: DockerClient) -> None:
-        """Build the target sysroot docker image."""
-        image_tag = self._platform.sysroot_image_tag
-
-        logger.info('Building sysroot image: %s', image_tag)
-        docker_client.build_image(
-            dockerfile_dir=self._target_sysroot,
-            dockerfile_name=ROS_DOCKERFILE_NAME,
-            tag=image_tag,
-            buildargs={
-                'BASE_IMAGE': self._platform.target_base_image,
-                'ROS_VERSION': self._platform.ros_version,
-            }
-        )
-        logger.info('Successfully created sysroot docker image: %s', image_tag)
+    logger.info('Building sysroot image: %s', image_tag)
+    docker_client.build_image(
+        dockerfile_name='sysroot.Dockerfile',
+        tag=image_tag,
+        buildargs={
+            'BASE_IMAGE': platform.target_base_image,
+            'ROS_VERSION': platform.ros_version,
+        }
+    )
+    logger.info('Successfully created sysroot docker image: %s', image_tag)

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -76,15 +76,17 @@ def prepare_docker_build_environment(
         custom_setup_dest.touch()
 
     # OSX performs emulation automatically
+    emulator_name = 'qemu-{}-static'.format(platform.qemu_arch)
+    bin_dir = docker_build_dir / 'bin'
+    bin_dir.mkdir(parents=True)
     if system() != 'Darwin':
-        emulator_path = Path('/') / 'usr' / 'bin' / 'qemu-{}-static'.format(platform.qemu_arch)
+        emulator_path = Path('/') / 'usr' / 'bin' / emulator_name
         if not emulator_path.is_file():
             raise RuntimeError('Could not find the expected QEmu emulator binary "{}"'.format(
                 emulator_path))
-
-    bin_dir = docker_build_dir / 'bin'
-    bin_dir.mkdir(parents=True)
-    _copyfile(emulator_path, bin_dir)
+        _copyfile(emulator_path, bin_dir)
+    else:
+        (bin_dir / emulator_name).touch()
 
     return docker_build_dir
 

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -24,7 +24,9 @@ from ros_cross_compile.platform import Platform
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-INTERNALS_DIR = Path('cc_internals')
+
+def build_internals_dir(platform: Platform) -> Path:
+    return Path('cc_internals') / str(platform)
 
 
 def _copytree(src: Path, dest: Path) -> None:
@@ -52,7 +54,7 @@ def prepare_docker_build_environment(
     :return The directory that was created.
     """
     package_dir = Path(__file__).parent
-    docker_build_dir = ros_workspace / INTERNALS_DIR / str(platform)
+    docker_build_dir = ros_workspace / build_internals_dir(platform)
     docker_build_dir.mkdir(parents=True)
 
     _copytree(package_dir / 'docker', docker_build_dir)

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -45,7 +45,7 @@ def setup_emulator(arch: str, output_dir: Path) -> None:
     """Copy the appropriate emulator binary to the output location."""
     emulator_name = 'qemu-{}-static'.format(arch)
     bin_dir = output_dir / 'bin'
-    bin_dir.mkdir(parents=True)
+    bin_dir.mkdir(parents=True, exist_ok=True)
     # OSX performs emulation automatically
     if host_system() != 'Darwin':
         emulator_path = Path('/') / 'usr' / 'bin' / emulator_name
@@ -74,7 +74,7 @@ def prepare_docker_build_environment(
     """
     package_dir = Path(__file__).parent
     docker_build_dir = ros_workspace / build_internals_dir(platform)
-    docker_build_dir.mkdir(parents=True)
+    docker_build_dir.mkdir(parents=True, exist_ok=True)
 
     _copytree(package_dir / 'docker', docker_build_dir)
     _copytree(package_dir / 'mixins', docker_build_dir / 'mixins')
@@ -83,7 +83,7 @@ def prepare_docker_build_environment(
     if custom_data_dir:
         _copytree(custom_data_dir, custom_data_dest)
     else:
-        custom_data_dest.mkdir()
+        custom_data_dest.mkdir(exist_ok=True)
 
     custom_setup_dest = docker_build_dir / 'user-custom-setup'
     if custom_setup_script:

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -17,8 +17,8 @@ import platform
 import docker
 import pytest
 
-from ros_cross_compile.dependencies import DEPENDENCY_SCRIPT_SUBPATH
 from ros_cross_compile.dependencies import gather_rosdeps
+from ros_cross_compile.dependencies import rosdep_install_script
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.platform import Platform
 
@@ -55,12 +55,12 @@ CUSTOM_KEY_PKG_XML = make_pkg_xml("""
 def test_dummy_ros2_pkg(tmpdir):
     ws = Path(str(tmpdir))
     pkg_xml = ws / 'src' / 'dummy' / 'package.xml'
-    out_script = ws / DEPENDENCY_SCRIPT_SUBPATH
     pkg_xml.parent.mkdir(parents=True)
     pkg_xml.write_text(RCLCPP_PKG_XML)
 
     client = DockerClient()
     platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
+    out_script = ws / rosdep_install_script(platform)
 
     gather_rosdeps(client, platform, workspace=ws)
     result = out_script.read_text().splitlines()
@@ -107,7 +107,7 @@ echo "yaml file:/test_rules.yaml" > /etc/ros/rosdep/sources.list.d/22-test-rules
     rosdep_setup.write_text(script_contents)
 
     gather_rosdeps(client, platform, workspace=ws, custom_script=rosdep_setup)
-    out_script = ws / DEPENDENCY_SCRIPT_SUBPATH
+    out_script = ws / rosdep_install_script(platform)
     result = out_script.read_text().splitlines()
     expected = [
         '#!/bin/bash',
@@ -151,7 +151,7 @@ echo "yaml file:/test_rules.yaml" > /etc/ros/rosdep/sources.list.d/22-test-rules
     gather_rosdeps(
         client, platform, workspace=ws, custom_script=rosdep_setup, custom_data_dir=data_dir)
 
-    out_script = ws / DEPENDENCY_SCRIPT_SUBPATH
+    out_script = ws / rosdep_install_script(platform)
     result = out_script.read_text().splitlines()
     expected = [
         '#!/bin/bash',

--- a/test/test_entrypoint.py
+++ b/test/test_entrypoint.py
@@ -12,12 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import Mock
+from unittest.mock import patch
 
-"""Unit tests for the `create_cc_sysroot.py` script."""
-
+# from ros_cross_compile.docker_client import DockerClient
+from ros_cross_compile.ros_cross_compile import cross_compile_pipeline
 from ros_cross_compile.ros_cross_compile import parse_args
 
 
-def test_trivial():
+def test_trivial_argparse():
     args = parse_args(['somepath', '-a', 'aarch64', '-o', 'ubuntu'])
     assert args
+
+
+def test_mocked_cc_pipeline(tmpdir):
+    args = parse_args([str(tmpdir), '-a', 'aarch64', '-o', 'ubuntu'])
+    with patch('ros_cross_compile.ros_cross_compile.DockerClient', Mock()) as docker_mock:
+        cross_compile_pipeline(args)
+        assert docker_mock.called
+        assert docker_mock().build_image.call_count == 2
+        assert docker_mock().run_container.call_count == 2

--- a/test/test_entrypoint.py
+++ b/test/test_entrypoint.py
@@ -19,5 +19,5 @@ from ros_cross_compile.ros_cross_compile import parse_args
 
 
 def test_trivial():
-    args = parse_args(['-a', 'aarch64', '-o', 'ubuntu'])
+    args = parse_args(['somepath', '-a', 'aarch64', '-o', 'ubuntu'])
     assert args

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -17,6 +17,7 @@
 
 import os
 from pathlib import Path
+from platform import system
 from unittest.mock import Mock
 
 from ros_cross_compile.platform import Platform
@@ -31,7 +32,7 @@ def test_prepare_docker_build_basic(tmpdir):
     tmp = Path(str(tmpdir))
     out_dir = prepare_docker_build_environment(platform, tmp, None, None)
 
-    if platform.system() != 'Darwin':
+    if system() != 'Darwin':
         assert (out_dir / 'bin' / 'qemu-arm-static').exists()
     assert (out_dir / 'rosdep.Dockerfile').exists()
     assert (out_dir / 'sysroot.Dockerfile').exists()

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -31,6 +31,7 @@ from ros_cross_compile.sysroot_creator import setup_emulator
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
+@patch('ros_cross_compile.sysroot_creator.host_system', side_effect=lambda: 'Linux')
 def test_emulator_not_installed(tmpdir):
     with pytest.raises(RuntimeError):
         setup_emulator('not-an-arch', Path(tmpdir))

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -31,7 +31,8 @@ def test_prepare_docker_build_basic(tmpdir):
     tmp = Path(str(tmpdir))
     out_dir = prepare_docker_build_environment(platform, tmp, None, None)
 
-    assert (out_dir / 'bin' / 'qemu-arm-static').exists()
+    if platform.system() != 'Darwin':
+        assert (out_dir / 'bin' / 'qemu-arm-static').exists()
     assert (out_dir / 'rosdep.Dockerfile').exists()
     assert (out_dir / 'sysroot.Dockerfile').exists()
 

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -17,151 +17,47 @@
 
 import os
 from pathlib import Path
-from typing import Tuple
 from unittest.mock import Mock
 
-import py
-import pytest
-from ros_cross_compile.sysroot_creator import Platform
-from ros_cross_compile.sysroot_creator import QEMU_DIR_NAME
-from ros_cross_compile.sysroot_creator import ROS_DOCKERFILE_NAME
-from ros_cross_compile.sysroot_creator import SYSROOT_DIR_NAME
-from ros_cross_compile.sysroot_creator import SysrootCreator
+from ros_cross_compile.platform import Platform
+from ros_cross_compile.sysroot_creator import create_workspace_sysroot_image
+from ros_cross_compile.sysroot_creator import prepare_docker_build_environment
 
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-@pytest.fixture
-def platform_config() -> Platform:
-    return Platform(
-        arch='aarch64',
-        os_name='ubuntu',
-        ros_distro='dashing')
+def test_prepare_docker_build_basic(tmpdir):
+    platform = Platform('armhf', 'debian', 'kinetic')
+    tmp = Path(str(tmpdir))
+    out_dir = prepare_docker_build_environment(platform, tmp, None, None)
+
+    assert (out_dir / 'bin' / 'qemu-arm-static').exists()
+    assert (out_dir / 'rosdep.Dockerfile').exists()
+    assert (out_dir / 'sysroot.Dockerfile').exists()
 
 
-def _default_docker_kwargs() -> dict:
-    return {
-        'platform': Platform('aarch64', 'ubuntu', 'dashing'),
-        'override_base_image': 'arm64v8/gcc:9.2.0',
-        'sysroot_nocache': False,
-    }
+def test_prepare_docker_build_with_user_custom(tmpdir):
+    platform = Platform('aarch64', 'ubuntu', 'eloquent')
+    tmp = Path(str(tmpdir))
+    this_dir = Path(__file__).parent
+    out_dir = prepare_docker_build_environment(
+        platform, tmp,
+        custom_data_dir=this_dir / 'data',
+        custom_setup_script=this_dir / 'user-custom-setup',
+    )
+
+    assert (out_dir / 'bin' / 'qemu-aarch64-static').exists()
+    assert (out_dir / 'rosdep.Dockerfile').exists()
+    assert (out_dir / 'sysroot.Dockerfile').exists()
+    assert (out_dir / 'custom-data' / 'arbitrary.txt')
+    assert (out_dir / 'user-custom-setup')
 
 
-def setup_mock_sysroot(path: py.path.local) -> Tuple[Path, Path]:
-    """Create mock directories to correctly construct the SysrootCreator."""
-    sysroot_dir = path / SYSROOT_DIR_NAME
-    sysroot_dir.mkdir()
-    ros_workspace_dir = sysroot_dir / 'ros_ws'
-    ros_workspace_dir.mkdir()
-    qemu_dir = sysroot_dir / QEMU_DIR_NAME
-    qemu_dir.mkdir()
-    qemu_binary_mock = qemu_dir / 'qemu'
-    qemu_binary_mock.ensure()
-    return sysroot_dir, ros_workspace_dir
-
-
-def test_sysroot_creator_constructor(
-        platform_config, tmpdir):
-    """Test the SysrootCreator constructor assuming valid path setup."""
-    # Create mock directories and files
-    sysroot_dir, ros_workspace_dir = setup_mock_sysroot(tmpdir)
-    sysroot_creator = SysrootCreator(str(tmpdir), 'ros_ws', platform_config)
-
-    assert isinstance(sysroot_creator.get_build_setup_script_path(), Path)
-    assert isinstance(sysroot_creator.get_system_setup_script_path(), Path)
-
-
-def test_sysroot_creator_constructor_argument_validation(platform_config, tmpdir):
-    """Make sure SysrootCreator constructor validates input types properly."""
-    sysroot_dir, ros_worspace_dir = setup_mock_sysroot(tmpdir)
-    root = str(tmpdir)
-    ws = 'ros_ws'
-    with pytest.raises(TypeError):
-        creator = SysrootCreator(tmpdir, ws, platform_config)
-    with pytest.raises(TypeError):
-        creator = SysrootCreator(root, Path(ws), platform_config)
-    with pytest.raises(TypeError):
-        creator = SysrootCreator(root, ws, 'not a Platform')
-
-    creator = SysrootCreator(root, ws, platform_config)
-    assert creator
-
-
-def test_custom_setup_script(platform_config, tmpdir):
-    sysroot_dir, ros_workspace_dir = setup_mock_sysroot(tmpdir)
-    compiler = SysrootCreator(
-        str(tmpdir), 'ros_ws', platform_config,
-        custom_setup_script_path=os.path.join(THIS_SCRIPT_DIR, 'custom-setup.sh'))
-    assert compiler
-    assert (sysroot_dir / 'user-custom-setup').exists()
-
-
-def test_custom_data_dir(platform_config, tmpdir):
-    sysroot_dir, ros_workspace_dir = setup_mock_sysroot(tmpdir)
-    compiler = SysrootCreator(
-        str(tmpdir), 'ros_ws', platform_config,
-        custom_data_dir=os.path.join(THIS_SCRIPT_DIR, 'data'))
-    assert compiler
-    assert (sysroot_dir / 'user-custom-data' / 'arbitrary.txt').exists()
-
-
-def test_sysroot_creator_tree_validation(platform_config, tmpdir):
-    """
-    Ensure that the SysrootCreator constructor validates the workspace.
-
-    Start with empty directory and add one piece at a time, expecting failures until
-    all parts are present.
-    """
-    kwargs = {
-        'cc_root_dir': str(tmpdir),
-        'ros_workspace_dir': 'ros_ws',
-        'platform': platform_config,
-        'custom_setup_script_path': None,
-    }
-
-    # There's no 'sysroot' at all yet
-    with pytest.raises(FileNotFoundError):
-        compiler = SysrootCreator(**kwargs)
-
-    sysroot_dir = tmpdir / SYSROOT_DIR_NAME
-    sysroot_dir.mkdir()
-    # ROS2 ws and qemu dirs are missing
-    with pytest.raises(FileNotFoundError):
-        compiler = SysrootCreator(**kwargs)
-
-    ros_workspace_dir = sysroot_dir / 'ros_ws'
-    ros_workspace_dir.mkdir()
-    # qemu dirs are missing
-    with pytest.raises(FileNotFoundError):
-        compiler = SysrootCreator(**kwargs)
-
-    qemu_dir = sysroot_dir / QEMU_DIR_NAME
-    qemu_dir.mkdir()
-    # the qemu binary is still missing
-    with pytest.raises(FileNotFoundError):
-        compiler = SysrootCreator(**kwargs)
-
-    qemu_binary_mock = qemu_dir / 'qemu'
-    qemu_binary_mock.ensure()
-    # everything is present now
-    compiler = SysrootCreator(**kwargs)
-    assert compiler
-
-
-def test_sysroot_creator_tree_additions(platform_config, tmpdir):
-    sysroot_dir, ros_workspace_dir = setup_mock_sysroot(tmpdir)
-    compiler = SysrootCreator(str(tmpdir), 'ros_ws', platform_config)
-    assert compiler
-    assert (sysroot_dir / ROS_DOCKERFILE_NAME).exists()
-    assert (sysroot_dir / 'mixins' / 'cross-compile.mixin').exists()
-    assert (sysroot_dir / 'mixins' / 'index.yaml').exists()
-
-
-def test_basic_sysroot_creation(platform_config, tmpdir):
+def test_basic_sysroot_creation(tmpdir):
     """Very simple smoke test to validate that syntax is correct."""
     # Very simple smoke test to validate that all internal syntax is correct
+
     mock_docker_client = Mock()
-    sysroot_dir, ros_workspace_dir = setup_mock_sysroot(tmpdir)
-    creator = SysrootCreator(str(tmpdir), 'ros_ws', platform_config)
-    creator.create_workspace_sysroot_image(mock_docker_client)
+    platform = Platform('aarch64', 'ubuntu', 'eloquent')
+    create_workspace_sysroot_image(mock_docker_client, platform)
     assert mock_docker_client.build_image.call_count == 1

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -19,12 +19,26 @@ import os
 from pathlib import Path
 from platform import system
 from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
 
 from ros_cross_compile.platform import Platform
 from ros_cross_compile.sysroot_creator import create_workspace_sysroot_image
 from ros_cross_compile.sysroot_creator import prepare_docker_build_environment
+from ros_cross_compile.sysroot_creator import setup_emulator
 
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_emulator_not_installed(tmpdir):
+    with pytest.raises(RuntimeError):
+        setup_emulator('not-an-arch', Path(tmpdir))
+
+
+@patch('ros_cross_compile.sysroot_creator.host_system', side_effect=lambda: 'Darwin')
+def test_emulator_touch(tmpdir):
+    setup_emulator('aarch64', Path(str(tmpdir)))
 
 
 def test_prepare_docker_build_basic(tmpdir):

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -32,13 +32,13 @@ THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 @patch('ros_cross_compile.sysroot_creator.host_system', side_effect=lambda: 'Linux')
-def test_emulator_not_installed(tmpdir):
+def test_emulator_not_installed(system_mock, tmpdir):
     with pytest.raises(RuntimeError):
         setup_emulator('not-an-arch', Path(str(tmpdir)))
 
 
 @patch('ros_cross_compile.sysroot_creator.host_system', side_effect=lambda: 'Darwin')
-def test_emulator_touch(tmpdir):
+def test_emulator_touch(system_mock, tmpdir):
     setup_emulator('aarch64', Path(str(tmpdir)))
 
 
@@ -51,6 +51,14 @@ def test_prepare_docker_build_basic(tmpdir):
         assert (out_dir / 'bin' / 'qemu-arm-static').exists()
     assert (out_dir / 'rosdep.Dockerfile').exists()
     assert (out_dir / 'sysroot.Dockerfile').exists()
+
+
+def test_run_twice(tmpdir):
+    # The test is that this doesn't throw an exception for already existing paths
+    platform = Platform('armhf', 'debian', 'kinetic')
+    tmp = Path(str(tmpdir))
+    prepare_docker_build_environment(platform, tmp, None, None)
+    prepare_docker_build_environment(platform, tmp, None, None)
 
 
 def test_prepare_docker_build_with_user_custom(tmpdir):

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -34,7 +34,7 @@ THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 @patch('ros_cross_compile.sysroot_creator.host_system', side_effect=lambda: 'Linux')
 def test_emulator_not_installed(tmpdir):
     with pytest.raises(RuntimeError):
-        setup_emulator('not-an-arch', Path(tmpdir))
+        setup_emulator('not-an-arch', Path(str(tmpdir)))
 
 
 @patch('ros_cross_compile.sysroot_creator.host_system', side_effect=lambda: 'Darwin')


### PR DESCRIPTION
Closes #137 

This change removes the requirement for a specific directory structure
* Make the target workspace a required positional argument
* Automatically create a directory, similar to the "sysroot directory" that we previously had users create manually, for the docker build context - it contains the necessary qemu binary, dockerfiles, scripts, and any other extra user inputs
* Update README.dmd to describe the simplified process

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>