### PR TITLE
Actually stream docker run output live and add test for it

### DIFF
--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -86,6 +86,7 @@ class DockerClient:
         command: Optional[str] = None,
         environment: Dict[str, str] = {},
         volumes: Dict[Path, str] = {},
+        container_name: Optional[str] = None,
     ) -> None:
         """
         Run a container of an existing image.
@@ -109,6 +110,7 @@ class DockerClient:
         # Do not `remove` so that the container can be queried for its exit code after finishing
         container = self._client.containers.run(
             image=image_name,
+            name=container_name,
             command=command,
             environment=environment,
             volumes=docker_volumes,
@@ -119,6 +121,7 @@ class DockerClient:
         for line in logs:
             logger.info(line.decode('utf-8').rstrip())
         exit_code = container.wait()
+        container.remove()
         if exit_code:
             raise docker.errors.ContainerError(
                 image_name, exit_code, '', image_name, 'See above ^')

--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -117,11 +117,15 @@ class DockerClient:
             detach=True,
             network_mode='host',
         )
-        logs = container.logs(stream=True)
-        for line in logs:
-            logger.info(line.decode('utf-8').rstrip())
-        exit_code = container.wait()
-        container.remove()
+        try:
+            logs = container.logs(stream=True)
+            for line in logs:
+                logger.info(line.decode('utf-8').rstrip())
+            exit_code = container.wait()
+        finally:
+            container.stop()
+            container.remove()
+
         if exit_code:
             raise docker.errors.ContainerError(
                 image_name, exit_code, '', image_name, 'See above ^')

--- a/test/test_docker_client.py
+++ b/test/test_docker_client.py
@@ -11,49 +11,69 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import platform
+import unittest
 
 import docker
 import pytest
 
 from ros_cross_compile.docker_client import DockerClient
 
-
-def test_parse_docker_build_output():
-    """Test the SysrootCreator constructor assuming valid path setup."""
-    # Create mock directories and files
-    client = DockerClient()
-    log_generator_without_errors = [
-        {'stream': ' ---\\u003e a9eb17255234\\n'},
-        {'stream': 'Step 1 : VOLUME /data\\n'},
-        {'stream': ' ---\\u003e Running in abdc1e6896c6\\n'},
-        {'stream': ' ---\\u003e 713bca62012e\\n'},
-        {'stream': 'Removing intermediate container abdc1e6896c6\\n'},
-        {'stream': 'Step 2 : CMD [\\"/bin/sh\\"]\\n'},
-        {'stream': ' ---\\u003e Running in dba30f2a1a7e\\n'},
-        {'stream': ' ---\\u003e 032b8b2855fc\\n'},
-        {'stream': 'Removing intermediate container dba30f2a1a7e\\n'},
-        {'stream': 'Successfully built 032b8b2855fc\\n'},
-    ]
-    # Just expect it not to raise
-    client._process_build_log(log_generator_without_errors)
-
-    log_generator_with_errors = [
-        {'stream': ' ---\\u003e a9eb17255234\\n'},
-        {'stream': 'Step 1 : VOLUME /data\\n'},
-        {'stream': ' ---\\u003e Running in abdc1e6896c6\\n'},
-        {'stream': ' ---\\u003e 713bca62012e\\n'},
-        {'stream': 'Removing intermediate container abdc1e6896c6\\n'},
-        {'stream': 'Step 2 : CMD [\\"/bin/sh\\"]\\n'},
-        {'error': ' ---\\COMMAND NOT FOUND\\n'},
-    ]
-    with pytest.raises(docker.errors.BuildError):
-        client._process_build_log(log_generator_with_errors)
+NO_MAC_REASON = 'CI environment cannot install Docker on Mac OS hosts.'
+IS_MAC = platform.system() == 'Darwin'
 
 
-@pytest.mark.skipif(
-    platform.system() == 'Darwin', reason='CI environment cannot run docker on Mac')
-def test_fail_docker_run():
-    client = DockerClient()
-    with pytest.raises(docker.errors.ContainerError):
-        client.run_container('alpine', command='/bin/sh -c "exit 1"')
+class DockerClientTest(unittest.TestCase):
+    def test_parse_docker_build_output(self):
+        """Test the SysrootCreator constructor assuming valid path setup."""
+        # Create mock directories and files
+        client = DockerClient()
+        log_generator_without_errors = [
+            {'stream': ' ---\\u003e a9eb17255234\\n'},
+            {'stream': 'Step 1 : VOLUME /data\\n'},
+            {'stream': ' ---\\u003e Running in abdc1e6896c6\\n'},
+            {'stream': ' ---\\u003e 713bca62012e\\n'},
+            {'stream': 'Removing intermediate container abdc1e6896c6\\n'},
+            {'stream': 'Step 2 : CMD [\\"/bin/sh\\"]\\n'},
+            {'stream': ' ---\\u003e Running in dba30f2a1a7e\\n'},
+            {'stream': ' ---\\u003e 032b8b2855fc\\n'},
+            {'stream': 'Removing intermediate container dba30f2a1a7e\\n'},
+            {'stream': 'Successfully built 032b8b2855fc\\n'},
+        ]
+        # Just expect it not to raise
+        client._process_build_log(log_generator_without_errors)
+
+        log_generator_with_errors = [
+            {'stream': ' ---\\u003e a9eb17255234\\n'},
+            {'stream': 'Step 1 : VOLUME /data\\n'},
+            {'stream': ' ---\\u003e Running in abdc1e6896c6\\n'},
+            {'stream': ' ---\\u003e 713bca62012e\\n'},
+            {'stream': 'Removing intermediate container abdc1e6896c6\\n'},
+            {'stream': 'Step 2 : CMD [\\"/bin/sh\\"]\\n'},
+            {'error': ' ---\\COMMAND NOT FOUND\\n'},
+        ]
+        with pytest.raises(docker.errors.BuildError):
+            client._process_build_log(log_generator_with_errors)
+
+    @pytest.mark.skipif(IS_MAC, reason=NO_MAC_REASON)
+    def test_fail_docker_run(self):
+        client = DockerClient()
+        with pytest.raises(docker.errors.ContainerError):
+            client.run_container('ubuntu:18.04', command='/bin/sh -c "exit 1"')
+
+    @pytest.mark.skipif(IS_MAC, reason=NO_MAC_REASON)
+    def test_stream(self):
+        client = DockerClient()
+        test_command = 'echo message1 && sleep 2 && echo message2'
+        with self.assertLogs('Docker Client', level='INFO') as cm:
+            client.run_container('ubuntu:18.04', command='/bin/sh -c "{}"'.format(test_command))
+
+        timestamps = [r.created for r in cm.records]
+        assert len(timestamps) == 2, 'Did not receive all expected messages'
+
+        # we know for sure that the logs were streaming if we printed them with a gap between
+        # we do not check for the full 2 seconds because sleep is not that precise,
+        # but even on the slowest test environment consecutive prints will not take a full second
+        timediff = timestamps[1] - timestamps[0]
+        assert timediff >= 1

--- a/test/test_docker_client.py
+++ b/test/test_docker_client.py
@@ -93,5 +93,5 @@ class DockerClientTest(unittest.TestCase):
         client.run_container(
             'ubuntu:18.04', command='/bin/sh -c "echo hello"', container_name=name)
 
-        containers = client._client.containers.list(all=True, filters={'name': name})
+        containers = api_client.containers.list(all=True, filters={'name': name})
         assert len(containers) == 0

--- a/test/test_docker_client.py
+++ b/test/test_docker_client.py
@@ -78,3 +78,20 @@ class DockerClientTest(unittest.TestCase):
         # but even on the slowest test environment consecutive prints will not take a full second
         timediff = timestamps[1] - timestamps[0]
         assert timediff >= 1
+
+    @pytest.mark.skipif(IS_MAC, reason=NO_MAC_REASON)
+    def test_removal(self):
+        client = DockerClient()
+        api_client = client._client
+        name = 'test_removing_run_container'
+        try:
+            preexisting_container = api_client.containers.get(name)
+            preexisting_container.remove()
+        except docker.errors.NotFound:
+            pass
+
+        client.run_container(
+            'ubuntu:18.04', command='/bin/sh -c "echo hello"', container_name=name)
+
+        containers = client._client.containers.list(all=True, filters={'name': name})
+        assert len(containers) == 0

--- a/test/test_docker_client.py
+++ b/test/test_docker_client.py
@@ -25,6 +25,7 @@ IS_MAC = platform.system() == 'Darwin'
 
 
 class DockerClientTest(unittest.TestCase):
+
     def test_parse_docker_build_output(self):
         """Test the SysrootCreator constructor assuming valid path setup."""
         # Create mock directories and files


### PR DESCRIPTION
Closes https://github.com/ros-tooling/cross_compile/issues/152

Ensure that `docker run` logs are streamed live as they run. I had earlier used an argument (`run(stream=True)`) that was added in a newer version of docker-py than the one we specify.

We can't remove the container automatically, then, because we have to query its exit code in order to raise an exception on a failure.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>