### PR TITLE
Create a common decorator for docker-based tests

### DIFF
--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pathlib import Path
-import platform
 
 import docker
 import pytest
@@ -22,11 +21,7 @@ from ros_cross_compile.dependencies import rosdep_install_script
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.platform import Platform
 
-NO_MAC_REASON = 'CI environment cannot install Docker on Mac OS hosts.'
-
-
-def is_mac():
-    return platform.system() == 'Darwin'
+from .utilities import uses_docker
 
 
 def make_pkg_xml(contents):
@@ -51,7 +46,7 @@ CUSTOM_KEY_PKG_XML = make_pkg_xml("""
 """)
 
 
-@pytest.mark.skipif(is_mac(), reason=NO_MAC_REASON)
+@uses_docker
 def test_dummy_ros2_pkg(tmpdir):
     ws = Path(str(tmpdir))
     pkg_xml = ws / 'src' / 'dummy' / 'package.xml'
@@ -74,7 +69,7 @@ def test_dummy_ros2_pkg(tmpdir):
     assert result == expected, 'Rosdep output did not meet expectations.'
 
 
-@pytest.mark.skipif(is_mac(), reason=NO_MAC_REASON)
+@uses_docker
 def test_rosdep_bad_key(tmpdir):
     ws = Path(str(tmpdir))
     pkg_xml = Path(ws) / 'src' / 'dummy' / 'package.xml'
@@ -86,7 +81,7 @@ def test_rosdep_bad_key(tmpdir):
         gather_rosdeps(client, platform, workspace=ws)
 
 
-@pytest.mark.skipif(is_mac(), reason=NO_MAC_REASON)
+@uses_docker
 def test_custom_rosdep_no_data_dir(tmpdir):
     script_contents = """
 cat > /test_rules.yaml <<EOF
@@ -118,7 +113,7 @@ echo "yaml file:/test_rules.yaml" > /etc/ros/rosdep/sources.list.d/22-test-rules
     assert result == expected, 'Rosdep output did not meet expectations.'
 
 
-@pytest.mark.skipif(is_mac(), reason=NO_MAC_REASON)
+@uses_docker
 def test_custom_rosdep_with_data_dir(tmpdir):
 
     rule_contents = """

--- a/test/test_docker_client.py
+++ b/test/test_docker_client.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import platform
 import unittest
 from unittest.mock import patch
 
@@ -21,8 +20,7 @@ import pytest
 
 from ros_cross_compile.docker_client import DockerClient
 
-NO_MAC_REASON = 'CI environment cannot install Docker on Mac OS hosts.'
-IS_MAC = platform.system() == 'Darwin'
+from .utilities import uses_docker
 
 
 class DockerClientTest(unittest.TestCase):
@@ -65,13 +63,13 @@ class DockerClientTest(unittest.TestCase):
         with pytest.raises(docker.errors.BuildError):
             client._process_build_log(log_generator_with_errors)
 
-    @pytest.mark.skipif(IS_MAC, reason=NO_MAC_REASON)
+    @uses_docker
     def test_fail_docker_run(self):
         client = DockerClient()
         with pytest.raises(docker.errors.ContainerError):
             client.run_container('ubuntu:18.04', command='/bin/sh -c "exit 1"')
 
-    @pytest.mark.skipif(IS_MAC, reason=NO_MAC_REASON)
+    @uses_docker
     def test_stream(self):
         client = DockerClient()
         test_command = 'echo message1 && sleep 2 && echo message2'
@@ -87,7 +85,7 @@ class DockerClientTest(unittest.TestCase):
         timediff = timestamps[1] - timestamps[0]
         assert timediff >= 1
 
-    @pytest.mark.skipif(IS_MAC, reason=NO_MAC_REASON)
+    @uses_docker
     def test_removal(self):
         client = DockerClient()
         api_client = client._client
@@ -100,7 +98,7 @@ class DockerClientTest(unittest.TestCase):
         containers = api_client.containers.list(all=True, filters={'name': name})
         assert len(containers) == 0
 
-    @pytest.mark.skipif(IS_MAC, reason=NO_MAC_REASON)
+    @uses_docker
     def test_removal_on_failure(self):
         client = DockerClient()
         api_client = client._client

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import platform
+
+import pytest
+
+
+def uses_docker(func):
+    """Decorate test to be skipped on platforms that don't have Docker for testing."""
+    NO_MAC_REASON = 'CI environment cannot install Docker on Mac OS hosts.'
+    IS_MAC = platform.system() == 'Darwin'
+
+    @functools.wraps(func)
+    @pytest.mark.skipif(IS_MAC, reason=NO_MAC_REASON)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper


### PR DESCRIPTION
Some logic was duplicated, so provided this much shorter decorator that can be changed all in one place.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>