### PR TITLE
Enabling x86 targets

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target_arch: [aarch64, armhf]
+        target_arch: [aarch64, armhf, x86_64]
         target_os: [ubuntu, debian]
         rosdistro: [dashing, eloquent, melodic]
     steps:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ using QEmu, #69 tracks progress toward enabling cross-compilation.
 
 This tool supports compiling a workspace for all combinations of the following:
 
-* Architecture: `armhf`, `aarch64`
+* Architecture: `armhf`, `aarch64`, `x86_64`
 * ROS Distro
   * ROS: `kinetic`, `melodic`
   * ROS 2: `dashing`, `eloquent`

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import getpass
+import platform
 from typing import NamedTuple
 from typing import Optional
 
@@ -22,6 +23,7 @@ ArchNameMapping = NamedTuple('ArchNameMapping', [('docker', str), ('qemu', str)]
 ARCHITECTURE_NAME_MAP = {
     'armhf': ArchNameMapping(docker='arm32v7', qemu='arm'),
     'aarch64': ArchNameMapping(docker='arm64v8', qemu='aarch64'),
+    'x86_64': ArchNameMapping(docker='', qemu='x86_64'),
 }
 SUPPORTED_ARCHITECTURES = tuple(ARCHITECTURE_NAME_MAP.keys())
 
@@ -87,8 +89,11 @@ class Platform:
             self._docker_target_base = override_base_image
         else:
             self._os_distro = ROSDISTRO_OS_MAP[self.ros_distro][self.os_name]
-            self._docker_target_base = '{}/{}:{}'.format(docker_org, self.os_name, self.os_distro)
             self._docker_native_base = '{}:{}'.format(self.os_name, self.os_distro)
+            if docker_org:
+                self._docker_target_base = '{}/{}'.format(docker_org, self._docker_native_base)
+            else:
+                self._docker_target_base = self._docker_native_base
 
     @property
     def arch(self):

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import getpass
-import platform
 from typing import NamedTuple
 from typing import Optional
 

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -88,11 +88,11 @@ class Platform:
             self._docker_target_base = override_base_image
         else:
             self._os_distro = ROSDISTRO_OS_MAP[self.ros_distro][self.os_name]
-            self._docker_native_base = '{}:{}'.format(self.os_name, self.os_distro)
+            native_base = '{}:{}'.format(self.os_name, self.os_distro)
             if docker_org:
-                self._docker_target_base = '{}/{}'.format(docker_org, self._docker_native_base)
+                self._docker_target_base = '{}/{}'.format(docker_org, native_base)
             else:
-                self._docker_target_base = self._docker_native_base
+                self._docker_target_base = native_base
 
     @property
     def arch(self):

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -15,7 +15,7 @@
 from distutils.dir_util import copy_tree
 import logging
 from pathlib import Path
-from platform import system as host_system
+import platform as py_platform
 import shutil
 from typing import Optional
 
@@ -46,8 +46,8 @@ def setup_emulator(arch: str, output_dir: Path) -> None:
     emulator_name = 'qemu-{}-static'.format(arch)
     bin_dir = output_dir / 'bin'
     bin_dir.mkdir(parents=True, exist_ok=True)
-    # OSX performs emulation automatically
-    if host_system() != 'Darwin':
+    needs_emulator = (py_platform.system() != 'Darwin') and (py_platform.machine() != arch)
+    if needs_emulator:
         emulator_path = Path('/') / 'usr' / 'bin' / emulator_name
         if not emulator_path.is_file():
             raise RuntimeError('Could not find the expected QEmu emulator binary "{}"'.format(

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -141,6 +141,8 @@ if [ "$arch" = 'armhf' ]; then
   expected_binary='ELF 32-bit LSB shared object, ARM'
 elif [ "$arch" = 'aarch64' ]; then
   expected_binary='ELF 64-bit LSB shared object, ARM aarch64'
+elif [ "$arch" = 'x86_64' ]; then
+  expected_binary='ELF 64-bit LSB shared object, x86-64'
 fi
 binary_file_info=$(file "$install_dir/$target_package/bin/dummy_binary")
 if [[ "$binary_file_info" != *"$expected_binary"* ]]; then

--- a/test/test_platform.py
+++ b/test/test_platform.py
@@ -48,6 +48,11 @@ def test_platform_argument_validation():
         p = Platform('armhf', 'rhel', 'dashing')
 
 
+def test_construct_x86():
+    p = Platform('x86_64', 'ubuntu', 'eloquent')
+    assert p
+
+
 def test_sysroot_image_tag(platform_config):
     """Make sure the image tag is created correctly."""
     image_tag = platform_config.sysroot_image_tag

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -31,13 +31,13 @@ from ros_cross_compile.sysroot_creator import setup_emulator
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-@patch('ros_cross_compile.sysroot_creator.host_system', side_effect=lambda: 'Linux')
+@patch('ros_cross_compile.sysroot_creator.py_platform.system', side_effect=lambda: 'Linux')
 def test_emulator_not_installed(system_mock, tmpdir):
     with pytest.raises(RuntimeError):
         setup_emulator('not-an-arch', Path(str(tmpdir)))
 
 
-@patch('ros_cross_compile.sysroot_creator.host_system', side_effect=lambda: 'Darwin')
+@patch('ros_cross_compile.sysroot_creator.py_platform.system', side_effect=lambda: 'Darwin')
 def test_emulator_touch(system_mock, tmpdir):
     setup_emulator('aarch64', Path(str(tmpdir)))
 


### PR DESCRIPTION
Closes https://github.com/ros-tooling/cross_compile/issues/118

Enables e2e test for x86 target. Runs considerably faster than the other e2e tests because it is not actually emulated, because our build hosts are x86

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>