### PR TITLE
Use a temporary directory specific to the virtualenv for tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ deps =
     pytest-runner
     yamllint
 commands =
-    pytest --cov=ros_cross_compile --cov-report=xml test/ {posargs}
+    pytest --basetemp="{envtmpdir}" --cov=ros_cross_compile --cov-report=xml test/ {posargs}


### PR DESCRIPTION
On some systems, `/tmp` cannot be mounted properly into Docker container volumes. To avoid this issue entirely, we utilize the virtualenv-specific tmp directory that tox provides.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>