### PR TITLE
Allow user to skip rosdep keys.

### DIFF
--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -15,6 +15,7 @@
 import logging
 import os
 from pathlib import Path
+from typing import List
 from typing import Optional
 
 from ros_cross_compile.docker_client import DockerClient
@@ -38,6 +39,7 @@ def gather_rosdeps(
     docker_client: DockerClient,
     platform: Platform,
     workspace: Path,
+    skip_rosdep_keys: List[str] = [],
     custom_script: Optional[Path] = None,
     custom_data_dir: Optional[Path] = None,
 ) -> None:
@@ -72,11 +74,12 @@ def gather_rosdeps(
     docker_client.run_container(
         image_name=image_name,
         environment={
+            'CUSTOM_SETUP': CUSTOM_SETUP,
+            'OUT_PATH': str(out_path),
             'OWNER_USER': str(os.getuid()),
             'ROSDISTRO': platform.ros_distro,
+            'SKIP_ROSDEP_KEYS': ' '.join(skip_rosdep_keys),
             'TARGET_OS': '{}:{}'.format(platform.os_name, platform.os_distro),
-            'OUT_PATH': str(out_path),
-            'CUSTOM_SETUP': CUSTOM_SETUP,
         },
         volumes=volumes,
     )

--- a/ros_cross_compile/docker/gather_rosdeps.sh
+++ b/ros_cross_compile/docker/gather_rosdeps.sh
@@ -32,6 +32,7 @@ rosdep install \
     --ignore-src \
     --reinstall \
     --default-yes \
+    --skip-keys "${SKIP_ROSDEP_KEYS}" \
     --simulate \
   >> "${OUT_PATH}"
 

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -116,7 +116,6 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         type=str,
         help='Relative path within the workspace to a file that provides colcon arguments. '
              'See "Package Selection and Build Customization" in README.md for more details.')
-
     parser.add_argument(
         '--skip-rosdep-collection',
         action='store_true',
@@ -125,6 +124,12 @@ def parse_args(args: List[str]) -> argparse.Namespace:
              'when running repeatedly during development, but has undefined behavior if'
              "the workspace's dependencies have changed since the last time"
              'collection was run.')
+    parser.add_argument(
+        '--skip-rosdep-keys',
+        default=[],
+        nargs='+',
+        help='Skips the rosdep keys. This helps user to skip the keys that are'
+             'not important for the compilation of package. ')
 
     return parser.parse_args(args)
 
@@ -135,6 +140,7 @@ def cross_compile_pipeline(
     platform = Platform(args.arch, args.os, args.rosdistro, args.sysroot_base_image)
 
     ros_workspace_dir = Path(args.ros_workspace)
+    skip_rosdep_keys = args.skip_rosdep_keys
     custom_data_dir = _path_if(args.custom_data_dir)
     custom_rosdep_script = _path_if(args.custom_rosdep_script)
     custom_setup_script = _path_if(args.custom_setup_script)
@@ -154,6 +160,7 @@ def cross_compile_pipeline(
             docker_client=docker_client,
             platform=platform,
             workspace=ros_workspace_dir,
+            skip_rosdep_keys=skip_rosdep_keys,
             custom_script=custom_rosdep_script,
             custom_data_dir=custom_data_dir)
     assert_install_rosdep_script_exists(ros_workspace_dir, platform)


### PR DESCRIPTION
Fixes #135.

This feature helps user to skip the rosdep keys that are not important for the compilation of package.

Signed-off-by: Snehal Bichkar <snehaldb@amazon.com>