### PR TITLE
Fix metric name in workflows

### DIFF
--- a/.github/workflows/pip_e2e_test.yml
+++ b/.github/workflows/pip_e2e_test.yml
@@ -62,4 +62,5 @@ jobs:
         aws-region: ${{ secrets.AWS_REGION }}
     - uses: ros-tooling/action-cloudwatch-metrics@0.0.4
       with:
+        metric-name: 'BuildsCanary'
         metric-value: ${{needs.test_macOS.result == 'success' && needs.test_ubuntu.result == 'success' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,5 +92,4 @@ jobs:
         aws-region: ${{ secrets.AWS_REGION }}
     - uses: ros-tooling/action-cloudwatch-metrics@0.0.4
       with:
-        metric-name: 'BuildsCanary'
         metric-value: ${{needs.test_macOS.result == 'success' && needs.test_ubuntu.result == 'success' }}


### PR DESCRIPTION
The nightly workflows should have a different metric name, and the test workflow should use the default name to match the other repositories.