### PR TITLE
Enable Foxy support

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         target_arch: [aarch64, armhf, x86_64]
         target_os: [ubuntu, debian]
-        rosdistro: [dashing, eloquent, melodic]
+        rosdistro: [dashing, eloquent, foxy, melodic]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool supports compiling a workspace for all combinations of the following:
 * Architecture: `armhf`, `aarch64`, `x86_64`
 * ROS Distro
   * ROS: `kinetic`, `melodic`
-  * ROS 2: `dashing`, `eloquent`
+  * ROS 2: `dashing`, `eloquent`, `foxy`
 * OS: `Ubuntu`, `Debian`
 
 NOTE: ROS 2 supports Debian only as a Tier 3 platform.

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
       cmake \
       python3-colcon-common-extensions \
       python3-colcon-mixin \
+      python3-dev \
       python3-pip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -26,7 +26,7 @@ ARCHITECTURE_NAME_MAP = {
 }
 SUPPORTED_ARCHITECTURES = tuple(ARCHITECTURE_NAME_MAP.keys())
 
-SUPPORTED_ROS2_DISTROS = ('dashing', 'eloquent')
+SUPPORTED_ROS2_DISTROS = ('dashing', 'eloquent', 'foxy')
 SUPPORTED_ROS_DISTROS = ('kinetic', 'melodic')
 
 ROSDISTRO_OS_MAP = {
@@ -44,6 +44,10 @@ ROSDISTRO_OS_MAP = {
     },
     'eloquent': {
         'ubuntu': 'bionic',
+        'debian': 'buster',
+    },
+    'foxy': {
+        'ubuntu': 'focal',
         'debian': 'buster',
     },
 }

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -82,11 +82,11 @@ setup(){
   target_package="dummy_pkg"
 
   custom_setup_script=${test_sysroot_dir}/custom-setup.bash
-  echo "#!/bin/bash" > ${custom_setup_script}
+  echo "#!/bin/bash" > "$custom_setup_script"
   if [ "$distro" == "foxy" ]; then
     # foxy is currently in prerelease and therefore is only available in the testing repo
     # this must be removed once foxy is released
-    echo "echo \"deb http://packages.ros.org/ros2-testing/ubuntu focal main\" >> /etc/apt/sources.list.d/ros2-latest.list" >> ${custom_setup_script}
+    echo "echo \"deb http://packages.ros.org/ros2-testing/ubuntu focal main\" >> /etc/apt/sources.list.d/ros2-latest.list" >> "$custom_setup_script"
   fi
 }
 
@@ -125,7 +125,7 @@ setup
 # Run the cross compilation script
 log "Executing cross compilation script..."
 python3 -m ros_cross_compile "$test_sysroot_dir" \
-  --arch "$arch" --os "$os" --rosdistro "$distro" --custom-setup-script ${custom_setup_script}
+  --arch "$arch" --os "$os" --rosdistro "$distro" --custom-setup-script "$custom_setup_script"
 CC_SCRIPT_STATUS=$?
 if [[ "$CC_SCRIPT_STATUS" -ne 0 ]]; then
   panic "Failed to run cross compile script."

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -80,6 +80,14 @@ setup(){
 
   cp -r "$dir/dummy_pkg" "$test_sysroot_dir/src"
   target_package="dummy_pkg"
+
+  custom_setup_script=${test_sysroot_dir}/custom-setup.bash
+  echo "#!/bin/bash" > ${custom_setup_script}
+  if [ "$distro" == "foxy" ]; then
+    # foxy is currently in prerelease and therefore is only available in the testing repo
+    # this must be removed once foxy is released
+    echo "echo \"deb http://packages.ros.org/ros2-testing/ubuntu focal main\" >> /etc/apt/sources.list.d/ros2-latest.list" >> ${custom_setup_script}
+  fi
 }
 
 # Argparser
@@ -117,7 +125,7 @@ setup
 # Run the cross compilation script
 log "Executing cross compilation script..."
 python3 -m ros_cross_compile "$test_sysroot_dir" \
-  --arch "$arch" --os "$os" --rosdistro "$distro"
+  --arch "$arch" --os "$os" --rosdistro "$distro" --custom-setup-script ${custom_setup_script}
 CC_SCRIPT_STATUS=$?
 if [[ "$CC_SCRIPT_STATUS" -ne 0 ]]; then
   panic "Failed to run cross compile script."

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -84,6 +84,10 @@ setup(){
   custom_setup_script=${test_sysroot_dir}/custom-setup.bash
   echo "#!/bin/bash" > "$custom_setup_script"
   if [ "$distro" == "foxy" ]; then
+    if [ "$arch" == "armhf" ]; then
+      error "Foxy does not yet have armhf binaries available"
+      exit 0
+    fi
     # foxy is currently in prerelease and therefore is only available in the testing repo
     # this must be removed once foxy is released
     echo "echo \"deb http://packages.ros.org/ros2-testing/ubuntu focal main\" >> /etc/apt/sources.list.d/ros2-latest.list" >> "$custom_setup_script"


### PR DESCRIPTION
Closes https://github.com/ros-tooling/cross_compile/issues/184
Depends on https://github.com/ros-tooling/cross_compile/pull/192

The Foxy beta is out, we can now build workspaces against it. However, since it's not officially released, we need to use the `ros2-testing` repo to install dependencies.

Probably won't merge this PR as-is, we should wait until Foxy is out, and the e2e requires no special setup. However, anybody who wants to try it out against the Foxy betas can check out this branch.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>