### PR TITLE
Pin flake8 version until ament_flake8 has a released version that supports the newest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament_lint-0.8.1&subdirectory=ament_lint
     git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament_mypy-0.8.1&subdirectory=ament_mypy
     git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament_pep257-0.8.1&subdirectory=ament_pep257
-    flake8
+    flake8<3.8
     flake8-blind-except
     flake8-builtins
     flake8-class-newline


### PR DESCRIPTION
Schedules / PR builds are failing to run ament_flake8 - e.g. https://github.com/ros-tooling/cross_compile/actions/runs/102916470

ament_flake8 has been fixed on master for flake8 3.8, but we only want to depend on officially released tagged versions.

For now, pin flake8 back to non-breaking version. We can follow up later with an update to ament_lint versions once a fix is available.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>