### PR TITLE
Mount Docker socket in volumes section

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
         python-version: [3.5, 3.6, 3.7]
     container:
       image: ubuntu:bionic
-      options: -v /var/run/docker.sock:/var/run/docker.sock
       volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
         - /__w/cross_compile/cross_compile:/__w/cross_compile/cross_compile
     steps:
     - name: Checkout sources


### PR DESCRIPTION
Move Docker socket mount from `options` into `volumes` since this is where it should belong.

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>