### PR TITLE
Use workspace expression so its not hardcoded into test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       image: ubuntu:bionic
       options: -v /var/run/docker.sock:/var/run/docker.sock
       volumes:
-        - /__w/cross_compile/cross_compile:/__w/cross_compile/cross_compile
+        - ${{ github.workspace }}/cross_compile:${{ github.workspace }}/cross_compile
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2


### PR DESCRIPTION
Use `${{ github.workspace }}` instead of hardcoding the workspace path.
This should make the tests more robust in case it ever changes. See https://github.com/ros-tooling/cross_compile/pull/194#issuecomment-627649437

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>