### PR TITLE
Allow relative paths for the workspace argument

### DIFF
--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -137,7 +137,12 @@ def cross_compile_pipeline(
 ):
     platform = Platform(args.arch, args.os, args.rosdistro, args.sysroot_base_image)
 
-    ros_workspace_dir = Path(args.ros_workspace)
+    ros_workspace_dir = Path(args.ros_workspace).resolve()
+    if not (ros_workspace_dir / 'src').is_dir():
+        raise ValueError(
+            'Specified workspace "{}" does not look like a colcon workspace '
+            '(there is no "src/" directory). Cannot continue'.format(ros_workspace_dir))
+
     skip_rosdep_keys = args.skip_rosdep_keys
     custom_data_dir = _path_if(args.custom_data_dir)
     custom_rosdep_script = _path_if(args.custom_rosdep_script)

--- a/test/test_entrypoint.py
+++ b/test/test_entrypoint.py
@@ -57,7 +57,7 @@ def test_relative_workspace(tmpdir):
     (tmp / 'src').mkdir()
     relative_dir = '.'
     args = parse_args([relative_dir, '-a', 'aarch64', '-o', 'ubuntu', '-d', 'foxy'])
-    with chdir(tmp), patch(
+    with chdir(str(tmp)), patch(
         'ros_cross_compile.ros_cross_compile.DockerClient', Mock()
     ), patch(
         'ros_cross_compile.ros_cross_compile.assert_install_rosdep_script_exists'

--- a/test/test_entrypoint.py
+++ b/test/test_entrypoint.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+import os
 from pathlib import Path
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -26,12 +28,47 @@ from ros_cross_compile.ros_cross_compile import cross_compile_pipeline
 from ros_cross_compile.ros_cross_compile import parse_args
 
 
+@contextlib.contextmanager
+def chdir(dirname: str):
+    """Provide a "with" statement for changing the working directory."""
+    curdir = os.getcwd()
+    try:
+        os.chdir(dirname)
+        yield
+    finally:
+        os.chdir(curdir)
+
+
 def test_trivial_argparse():
     args = parse_args(['somepath', '-a', 'aarch64', '-o', 'ubuntu'])
     assert args
 
 
+def test_bad_workspace(tmpdir):
+    args = parse_args([str(tmpdir), '-a', 'aarch64', '-o', 'ubuntu', '-d', 'foxy'])
+    with pytest.raises(ValueError):
+        cross_compile_pipeline(args)
+
+
+def test_relative_workspace(tmpdir):
+    # Change directory to the tmp dir and invoke using '.' as the
+    # workspace to check if relative paths work
+    tmp = Path(str(tmpdir))
+    (tmp / 'src').mkdir()
+    relative_dir = '.'
+    args = parse_args([relative_dir, '-a', 'aarch64', '-o', 'ubuntu', '-d', 'foxy'])
+    with chdir(tmp), patch(
+        'ros_cross_compile.ros_cross_compile.DockerClient', Mock()
+    ), patch(
+        'ros_cross_compile.ros_cross_compile.assert_install_rosdep_script_exists'
+    ):
+        # should not raise an exception
+        cross_compile_pipeline(args)
+
+
 def test_mocked_cc_pipeline(tmpdir):
+    tmp = Path(str(tmpdir))
+    (tmp / 'src').mkdir()
     args = parse_args([str(tmpdir), '-a', 'aarch64', '-o', 'ubuntu'])
     with patch(
         'ros_cross_compile.ros_cross_compile.DockerClient', Mock()


### PR DESCRIPTION
Allow relative paths for the workspace argument (via `resolve`), and check early if it looks usable, to prevent waiting until later in the process to raise an issue.

Fixes #214 

Signed-off-by: Emerson Knapp <eknapp@amazon.com>