### PR TITLE
Fix units to be units instead of measurable properties

### DIFF
--- a/ros_cross_compile/data_collector.py
+++ b/ros_cross_compile/data_collector.py
@@ -33,8 +33,8 @@ Datum = NamedTuple('Datum', [('name', str),
 
 
 class Units(Enum):
-    time = 'seconds'
-    size = 'bytes'
+    seconds = 'seconds'
+    bytes = 'bytes'
 
 
 class DataCollector:
@@ -61,7 +61,7 @@ class DataCollector:
         finally:
             elapsed = time.monotonic() - start
             time_metric = Datum(name + '-time', elapsed,
-                                Units.time.value, time.monotonic(), complete)
+                                Units.seconds.value, time.monotonic(), complete)
             self.add_datum(time_metric)
 
 

--- a/ros_cross_compile/data_collector.py
+++ b/ros_cross_compile/data_collector.py
@@ -33,8 +33,8 @@ Datum = NamedTuple('Datum', [('name', str),
 
 
 class Units(Enum):
-    seconds = 'seconds'
-    bytes = 'bytes'
+    Seconds = 'seconds'
+    Bytes = 'bytes'
 
 
 class DataCollector:
@@ -61,7 +61,7 @@ class DataCollector:
         finally:
             elapsed = time.monotonic() - start
             time_metric = Datum(name + '-time', elapsed,
-                                Units.seconds.value, time.monotonic(), complete)
+                                Units.Seconds.value, time.monotonic(), complete)
             self.add_datum(time_metric)
 
 


### PR DESCRIPTION
Merged before fixing this from previous PR - make the Units enum contain members naming units of measurement, not measurable properties.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>