### PR TITLE
Add Customizations Tuple

### DIFF
--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -23,6 +23,12 @@ from pathlib import Path
 from typing import List, NamedTuple, Optional
 
 
+"""
+A NamedTuple that collects the customizations for each stage passed in by the user.
+
+As such, the documentation for each customization can be found by looking at the
+argparse options in ros_cross_compile.py.
+"""
 PipelineStageConfigOptions = NamedTuple('PipelineStageConfigOptions',
                                         [('skip_rosdep_collection', bool),
                                          ('skip_rosdep_keys', List[str]),

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Wrapper abstractions for each pipeline stage.
+
+The abstractions allows for streamlining the pipeline into a unified
+'pipeline runner' and collecting of time series data from each stage.
+"""
+
+from pathlib import Path
+from typing import List, NamedTuple, Optional
+
+
+ConfigOptions = NamedTuple('ConfigOptions', [('skip_rosdep_collection', Optional[bool]),
+                                             ('skip_rosdep_keys', List[str]),
+                                             ('custom_script', Optional[Path]),
+                                             ('custom_data_dir', Optional[Path]),
+                                             ('custom_setup_script', Optional[Path])])

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Wrapper abstractions for each pipeline stage.
-
-The abstractions allows for streamlining the pipeline into a unified
-'pipeline runner' and collecting of time series data from each stage.
-"""
-
 from pathlib import Path
 from typing import List, NamedTuple, Optional
 

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -23,8 +23,9 @@ from pathlib import Path
 from typing import List, NamedTuple, Optional
 
 
-ConfigOptions = NamedTuple('ConfigOptions', [('skip_rosdep_collection', Optional[bool]),
-                                             ('skip_rosdep_keys', List[str]),
-                                             ('custom_script', Optional[Path]),
-                                             ('custom_data_dir', Optional[Path]),
-                                             ('custom_setup_script', Optional[Path])])
+PipelineStageConfigOptions = NamedTuple('PipelineStageConfigOptions',
+                                        [('skip_rosdep_collection', bool),
+                                         ('skip_rosdep_keys', List[str]),
+                                         ('custom_script', Optional[Path]),
+                                         ('custom_data_dir', Optional[Path]),
+                                         ('custom_setup_script', Optional[Path])])

--- a/test/test_pipeline_stages.py
+++ b/test/test_pipeline_stages.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from ros_cross_compile.pipeline_stages import ConfigOptions
+
+
+def test_config_tuple_creation():
+    test_options = ConfigOptions(True, False, Path('./'), Path('./'), Path('./'))
+
+    assert test_options
+
+    assert test_options.skip_rosdep_collection is True
+    assert test_options.skip_rosdep_keys is False
+    assert test_options.custom_script == Path('./')
+    assert test_options.custom_data_dir == Path('./')
+    assert test_options.custom_setup_script == Path('./')

--- a/test/test_pipeline_stages.py
+++ b/test/test_pipeline_stages.py
@@ -18,12 +18,5 @@ from ros_cross_compile.pipeline_stages import ConfigOptions
 
 
 def test_config_tuple_creation():
-    test_options = ConfigOptions(True, False, Path('./'), Path('./'), Path('./'))
-
+    test_options = ConfigOptions(True, ['abc', 'def'], Path('./'), Path('./'), Path('./'))
     assert test_options
-
-    assert test_options.skip_rosdep_collection is True
-    assert test_options.skip_rosdep_keys is False
-    assert test_options.custom_script == Path('./')
-    assert test_options.custom_data_dir == Path('./')
-    assert test_options.custom_setup_script == Path('./')

--- a/test/test_pipeline_stages.py
+++ b/test/test_pipeline_stages.py
@@ -18,5 +18,6 @@ from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
 
 
 def test_config_tuple_creation():
-    test_options = PipelineStageConfigOptions(True, ['abc', 'def'], Path('./'), Path('./'), Path('./'))
+    test_options = PipelineStageConfigOptions(True, ['abc', 'def'], Path('./'),
+                                              Path('./'), Path('./'))
     assert test_options

--- a/test/test_pipeline_stages.py
+++ b/test/test_pipeline_stages.py
@@ -14,9 +14,9 @@
 
 from pathlib import Path
 
-from ros_cross_compile.pipeline_stages import ConfigOptions
+from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
 
 
 def test_config_tuple_creation():
-    test_options = ConfigOptions(True, ['abc', 'def'], Path('./'), Path('./'), Path('./'))
+    test_options = PipelineStageConfigOptions(True, ['abc', 'def'], Path('./'), Path('./'), Path('./'))
     assert test_options


### PR DESCRIPTION
In an upcoming PR, we will move the current `ros_cross_compile` pipeline to an "abstractified" system that takes advantage of Abstract Base Classes (ABCs). In preparation for that, we add a new customizations tuple, which will streamline this new system.