### PR TITLE
Add interface for pipeline stage abstraction and implement dependencies stage

### DIFF
--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -111,16 +111,16 @@ class DependenciesStage(PipelineStage):
         super().__init__('gather_rosdeps')
 
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
-                 customizations: PipelineStageConfigOptions):
+                 pipeline_stage_config_options: PipelineStageConfigOptions):
         """In the event of a failure, a RuntimeError can be raised."""
         # NOTE: Stage skipping will be handled more generically in the future;
         # for now we handle this specific case internally to maintain the original API.
-        if not customizations.skip_rosdep_collection:
+        if not pipeline_stage_config_options.skip_rosdep_collection:
             gather_rosdeps(
                 docker_client=docker_client,
                 platform=platform,
                 workspace=ros_workspace_dir,
-                skip_rosdep_keys=customizations.skip_rosdep_keys,
-                custom_script=customizations.custom_script,
-                custom_data_dir=customizations.custom_data_dir)
+                skip_rosdep_keys=pipeline_stage_config_options.skip_rosdep_keys,
+                custom_script=pipeline_stage_config_options.custom_script,
+                custom_data_dir=pipeline_stage_config_options.custom_data_dir)
         assert_install_rosdep_script_exists(ros_workspace_dir, platform)

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -112,7 +112,12 @@ class DependenciesStage(PipelineStage):
 
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
                  pipeline_stage_config_options: PipelineStageConfigOptions):
-        """In the event of a failure, a RuntimeError can be raised."""
+        """
+        Run the inspection and output the dependency installation script.
+
+        :raises RuntimeError if the step was skipped when no dependency script has been
+        previously generated
+        """
         # NOTE: Stage skipping will be handled more generically in the future;
         # for now we handle this specific case internally to maintain the original API.
         if not pipeline_stage_config_options.skip_rosdep_collection:

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -100,13 +100,21 @@ def assert_install_rosdep_script_exists(
 
 
 class DependenciesStage(PipelineStage):
-    """Wrapper class for running the dependencies stage of the pipeline."""
+    """
+    This stage determines what external dependencies are needed for building.
+
+    It outputs a script into the internals directory that will install those
+    dependencies for the target platform.
+    """
 
     def __init__(self):
-        self.name = gather_rosdeps.__name__
+        super().__init__('gather_rosdeps')
 
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
                  customizations: PipelineStageConfigOptions):
+        """In the event of a failure, a RuntimeError can be raised."""
+        # NOTE: Stage skipping will be handled more generically in the future;
+        # for now we handle this specific case internally to maintain the original API.
         if not customizations.skip_rosdep_collection:
             gather_rosdeps(
                 docker_client=docker_client,

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from abc import ABCMeta
 from pathlib import Path
 from typing import List, NamedTuple, Optional
+
+from ros_cross_compile.docker_client import DockerClient
+from ros_cross_compile.platform import Platform
 
 
 """
@@ -28,3 +32,14 @@ PipelineStageConfigOptions = NamedTuple('PipelineStageConfigOptions',
                                          ('custom_script', Optional[Path]),
                                          ('custom_data_dir', Optional[Path]),
                                          ('custom_setup_script', Optional[Path])])
+
+
+class PipelineStage(metaclass=ABCMeta):
+    """Interface to represent a stage of the cross compile pipeline."""
+
+    def __init__(self):
+        self.name = ''
+
+    def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
+                 customizations: PipelineStageConfigOptions):
+        pass

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from typing import List, NamedTuple, Optional
 
@@ -37,9 +37,11 @@ PipelineStageConfigOptions = NamedTuple('PipelineStageConfigOptions',
 class PipelineStage(metaclass=ABCMeta):
     """Interface to represent a stage of the cross compile pipeline."""
 
-    def __init__(self):
-        self.name = ''
+    @abstractmethod
+    def __init__(self, name):
+        self._name = name
 
+    @abstractmethod
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
                  customizations: PipelineStageConfigOptions):
         pass

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List, NamedTuple, Optional
 
@@ -34,7 +34,7 @@ PipelineStageConfigOptions = NamedTuple('PipelineStageConfigOptions',
                                          ('custom_setup_script', Optional[Path])])
 
 
-class PipelineStage(metaclass=ABCMeta):
+class PipelineStage(ABC):
     """Interface to represent a stage of the cross compile pipeline."""
 
     @abstractmethod
@@ -44,4 +44,4 @@ class PipelineStage(metaclass=ABCMeta):
     @abstractmethod
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
                  customizations: PipelineStageConfigOptions):
-        pass
+        raise NotImplementedError

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -60,7 +60,11 @@ def test_dummy_ros2_pkg(tmpdir):
     platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
     out_script = ws / rosdep_install_script(platform)
 
-    gather_rosdeps(client, platform, workspace=ws)
+    customizations = PipelineStageConfigOptions(False, [], None, None, None)
+    temp_stage = DependenciesStage()
+
+    temp_stage(platform, client, ws, customizations)
+
     result = out_script.read_text()
     assert 'ros-dashing-ament-cmake' in result
     assert 'ros-dashing-rclcpp' in result
@@ -204,27 +208,6 @@ def test_dummy_skip_rosdep_multiple_keys_pkg(tmpdir):
     result = out_script.read_text()
     assert 'ros-dashing-ament-cmake' not in result
     assert 'ros-dashing-rclcpp' not in result
-
-
-@uses_docker
-def test_dependencies_stage_call(tmpdir):
-    ws = Path(str(tmpdir))
-    pkg_xml = ws / 'src' / 'dummy' / 'package.xml'
-    pkg_xml.parent.mkdir(parents=True)
-    pkg_xml.write_text(RCLCPP_PKG_XML)
-
-    client = DockerClient()
-    platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
-    out_script = ws / rosdep_install_script(platform)
-
-    customizations = PipelineStageConfigOptions(False, [], None, None, None)
-    temp_stage = DependenciesStage()
-
-    temp_stage(platform, client, ws, customizations)
-
-    result = out_script.read_text()
-    assert 'ros-dashing-ament-cmake' in result
-    assert 'ros-dashing-rclcpp' in result
 
 
 def test_dependencies_stage_creation():

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -60,6 +60,7 @@ def test_dummy_ros2_pkg(tmpdir):
     platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
     out_script = ws / rosdep_install_script(platform)
 
+    # a default set of customizations for the dependencies stage
     customizations = PipelineStageConfigOptions(False, [], None, None, None)
     temp_stage = DependenciesStage()
 

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -17,6 +17,7 @@ import shutil
 import docker
 import pytest
 
+from ros_cross_compile.dependencies import DependenciesStage
 from ros_cross_compile.dependencies import gather_rosdeps
 from ros_cross_compile.dependencies import rosdep_install_script
 from ros_cross_compile.docker_client import DockerClient
@@ -202,3 +203,13 @@ def test_dummy_skip_rosdep_multiple_keys_pkg(tmpdir):
     result = out_script.read_text()
     assert 'ros-dashing-ament-cmake' not in result
     assert 'ros-dashing-rclcpp' not in result
+
+
+def test_dependencies_stage_creation():
+    temp_stage = DependenciesStage()
+    assert temp_stage
+
+
+def test_dependencies_stage_name():
+    temp_stage = DependenciesStage()
+    assert temp_stage.name == gather_rosdeps.__name__


### PR DESCRIPTION
The pipeline stage abstraction is an ABC, and we implement the dependencies stage in this PR to essentially give an example as to how each pipeline stage class would be implemented.

Signed-off-by: Siddharth Gollapudi <sgollapu@amazon.com>