### PR TITLE
Don't swallow exceptions in the timer

### DIFF
--- a/ros_cross_compile/data_collector.py
+++ b/ros_cross_compile/data_collector.py
@@ -53,11 +53,10 @@ class DataCollector:
     def data_timer(self, name: str):
         """Provide an interface to time a statement's duration with a 'with'."""
         start = time.monotonic()
-        complete = True
+        complete = False
         try:
             yield
-        except Exception:
-            complete = False
+            complete = True
         finally:
             elapsed = time.monotonic() - start
             time_metric = Datum(name + '-time', elapsed,

--- a/test/test_data_collector.py
+++ b/test/test_data_collector.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.data_collector import DataWriter
 from ros_cross_compile.data_collector import Datum
@@ -57,9 +59,12 @@ def test_data_timer_can_time():
 
 def test_data_timer_error_handling():
     test_collector = DataCollector()
-    with test_collector.data_timer('test_time_fail'):
-        raise Exception
+    # The timer should not hide the exception, we expect it to add the datum value
+    with pytest.raises(Exception):
+        with test_collector.data_timer('test_time_fail'):
+            raise Exception
 
+    assert len(test_collector._data) > 0
     assert test_collector._data[0].complete is False
 
 


### PR DESCRIPTION
Meaningful exceptions are provided by code to convey error conditions. The data timer currently suppresses these from being raised and allows the program to silently return a successful return code when a failure happens. Fix that.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>