### PR TITLE
Add more informative messaging when user provides unsupported OS value

### DIFF
--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -87,7 +87,8 @@ class Platform:
         os_map = ROSDISTRO_OS_MAP[self.ros_distro]
         if self.os_name not in os_map:
             raise ValueError(
-                'OS "{}" not supported for ROS distro "{}". Supported values: {}'.format(
+                'OS "{}" not supported for ROS distro "{}". Supported values: {} '
+                '(note that these are case sensitive)'.format(
                     os_name, ros_distro, list(os_map.keys())))
 
         if override_base_image:

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -84,9 +84,11 @@ class Platform:
         else:
             raise ValueError('Unknown ROS distribution "{}" specified'.format(ros_distro))
 
-        if self.os_name not in ROSDISTRO_OS_MAP[self.ros_distro]:
+        os_map = ROSDISTRO_OS_MAP[self.ros_distro]
+        if self.os_name not in os_map:
             raise ValueError(
-                'OS "{}" not supported for ROS distro "{}"'.format(os_name, ros_distro))
+                'OS "{}" not supported for ROS distro "{}". Supported values: {}'.format(
+                    os_name, ros_distro, list(os_map.keys())))
 
         if override_base_image:
             self._docker_target_base = override_base_image


### PR DESCRIPTION
The values are case sensitive, and since we may support different OS values per ROS distribution/architecture, we cannot list this as "choices" in the argparser. Add the supported values to make the situation more clear to the user.

Sample:
```
(venv) 5:40:13 ➜  tiny ros_cross_compile -a aarch64 -o Ubuntu -d foxy .                                                           1s
Traceback (most recent call last):
  File "/Users/eknapp/dev/ros/infra/venv/bin/ros_cross_compile", line 11, in <module>
    load_entry_point('ros-cross-compile', 'console_scripts', 'ros_cross_compile')()
  File "/Users/eknapp/dev/ros/infra/cross_compile/ros_cross_compile/ros_cross_compile.py", line 191, in main
    cross_compile_pipeline(args)
  File "/Users/eknapp/dev/ros/infra/cross_compile/ros_cross_compile/ros_cross_compile.py", line 151, in cross_compile_pipeline
    platform = Platform(args.arch, args.os, args.rosdistro, args.sysroot_base_image)
  File "/Users/eknapp/dev/ros/infra/cross_compile/ros_cross_compile/platform.py", line 91, in __init__
    os_name, ros_distro, list(os_map.keys())))
ValueError: OS "Ubuntu" not supported for ROS distro "foxy". Supported values: ['ubuntu', 'debian']
```

Signed-off-by: Emerson Knapp <eknapp@amazon.com>