### PR TITLE
Rename data_timer api to just "timer"

### DIFF
--- a/ros_cross_compile/data_collector.py
+++ b/ros_cross_compile/data_collector.py
@@ -50,7 +50,7 @@ class DataCollector:
         return list(map(lambda d: d._asdict(), self._data))
 
     @contextmanager
-    def data_timer(self, name: str):
+    def timer(self, name: str):
         """Provide an interface to time a statement's duration with a 'with'."""
         start = time.monotonic()
         complete = False

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -187,7 +187,7 @@ def main():
     data_writer = DataWriter(ros_workspace_dir)
 
     try:
-        with data_collector.data_timer('cross_compile_end_to_end'):
+        with data_collector.timer('cross_compile_end_to_end'):
             cross_compile_pipeline(args)
     finally:
         data_writer.write(data_collector)

--- a/test/test_data_collector.py
+++ b/test/test_data_collector.py
@@ -48,20 +48,20 @@ def test_data_collection():
     assert to_test_data[0].complete
 
 
-def test_data_timer_can_time():
+def test_timer_can_time():
     test_collector = DataCollector()
-    with test_collector.data_timer('test_time'):
+    with test_collector.timer('test_time'):
         pass
 
     assert test_collector._data[0].complete
     assert test_collector._data[0].value > 0
 
 
-def test_data_timer_error_handling():
+def test_timer_error_handling():
     test_collector = DataCollector()
     # The timer should not hide the exception, we expect it to add the datum value
     with pytest.raises(Exception):
-        with test_collector.data_timer('test_time_fail'):
+        with test_collector.timer('test_time_fail'):
             raise Exception
 
     assert len(test_collector._data) > 0


### PR DESCRIPTION
The naming was redundant, "data_" added no useful context

Signed-off-by: Emerson Knapp <eknapp@amazon.com>