### PR TITLE
Implement the remainder of the cross compile stages

### DIFF
--- a/ros_cross_compile/builders.py
+++ b/ros_cross_compile/builders.py
@@ -16,6 +16,8 @@ import os
 from pathlib import Path
 
 from ros_cross_compile.docker_client import DockerClient
+from ros_cross_compile.pipeline_stages import PipelineStage
+from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
 from ros_cross_compile.platform import Platform
 
 logging.basicConfig(level=logging.INFO)
@@ -45,3 +47,18 @@ def run_emulated_docker_build(
             workspace_path: '/ros_ws',
         },
     )
+
+
+class DockerBuildStage(PipelineStage):
+    """
+    This stage spins up a docker container and runs the emulated build with it.
+
+    Uses the sysroot image from the previous stage.
+    """
+
+    def __init__(self):
+        super().__init__('run_emulated_docker_build')
+
+    def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
+                 pipeline_stage_config_options: PipelineStageConfigOptions):
+        run_emulated_docker_build(docker_client, platform, ros_workspace_dir)

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -20,6 +20,8 @@ import shutil
 from typing import Optional
 
 from ros_cross_compile.docker_client import DockerClient
+from ros_cross_compile.pipeline_stages import PipelineStage
+from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
 from ros_cross_compile.platform import Platform
 
 logging.basicConfig(level=logging.INFO)
@@ -120,3 +122,18 @@ def create_workspace_sysroot_image(
         }
     )
     logger.info('Successfully created sysroot docker image: %s', image_tag)
+
+
+class CreateSysrootStage(PipelineStage):
+    """
+    This stage creates the target platform Docker sysroot image.
+
+    It will output the sysroot image.
+    """
+
+    def __init__(self):
+        super().__init__('create_workspace_sysroot_image')
+
+    def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
+                 pipeline_stage_config_options: PipelineStageConfigOptions):
+        create_workspace_sysroot_image(docker_client, platform)

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -14,7 +14,9 @@
 from pathlib import Path
 from unittest.mock import Mock
 
+from ros_cross_compile.builders import DockerBuildStage
 from ros_cross_compile.builders import run_emulated_docker_build
+from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
 from ros_cross_compile.platform import Platform
 
 
@@ -22,5 +24,21 @@ def test_emulated_docker_build():
     # Very simple smoke test to validate that all internal syntax is correct
     mock_docker_client = Mock()
     platform = Platform('aarch64', 'ubuntu', 'eloquent')
-    run_emulated_docker_build(mock_docker_client, platform, Path('dummy_path'))
+
+    # a default set of customizations for the docker build stage
+    customizations = PipelineStageConfigOptions(False, [], None, None, None)
+    temp_stage = DockerBuildStage()
+
+    temp_stage(platform, mock_docker_client, Path('dummy_path'), customizations)
+
     assert mock_docker_client.run_container.call_count == 1
+
+
+def test_docker_build_stage_creation():
+    temp_stage = DockerBuildStage()
+    assert temp_stage
+
+
+def test_docker_build_stage_name():
+    temp_stage = DockerBuildStage()
+    assert temp_stage._name == run_emulated_docker_build.__name__

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -23,8 +23,10 @@ from unittest.mock import patch
 
 import pytest
 
+from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
 from ros_cross_compile.platform import Platform
 from ros_cross_compile.sysroot_creator import create_workspace_sysroot_image
+from ros_cross_compile.sysroot_creator import CreateSysrootStage
 from ros_cross_compile.sysroot_creator import prepare_docker_build_environment
 from ros_cross_compile.sysroot_creator import setup_emulator
 
@@ -84,5 +86,20 @@ def test_basic_sysroot_creation(tmpdir):
 
     mock_docker_client = Mock()
     platform = Platform('aarch64', 'ubuntu', 'eloquent')
-    create_workspace_sysroot_image(mock_docker_client, platform)
+
+    # a default set of customizations for the docker build stage
+    customizations = PipelineStageConfigOptions(False, [], None, None, None)
+    temp_stage = CreateSysrootStage()
+
+    temp_stage(platform, mock_docker_client, Path('dummy_path'), customizations)
     assert mock_docker_client.build_image.call_count == 1
+
+
+def test_create_sysroot_stage_creation():
+    temp_stage = CreateSysrootStage()
+    assert temp_stage
+
+
+def test_create_sysroot_stage_name():
+    temp_stage = CreateSysrootStage()
+    assert temp_stage._name == create_workspace_sysroot_image.__name__


### PR DESCRIPTION
Add implementations for the sysroot image creation stage and the emulated docker build stage. Also adds tests for the new stages in.

Signed-off-by: Siddharth Gollapudi <sgollapu@amazon.com>