### PR TITLE
Add the remainder of the stages to the pipeline runner

### DIFF
--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -110,10 +110,6 @@ class DependenciesStage(PipelineStage):
     def __init__(self):
         super().__init__('gather_rosdeps')
 
-    @property
-    def name(self):
-        return self._name
-
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
                  pipeline_stage_config_options: PipelineStageConfigOptions):
         """

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -41,6 +41,10 @@ class PipelineStage(ABC):
     def __init__(self, name):
         self._name = name
 
+    @property
+    def name(self):
+        return self._name
+
     @abstractmethod
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
                  customizations: PipelineStageConfigOptions):

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -23,7 +23,7 @@ import sys
 from typing import List
 from typing import Optional
 
-from ros_cross_compile.builders import run_emulated_docker_build
+from ros_cross_compile.builders import DockerBuildStage
 from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.data_collector import DataWriter
 from ros_cross_compile.dependencies import DependenciesStage
@@ -34,7 +34,7 @@ from ros_cross_compile.platform import Platform
 from ros_cross_compile.platform import SUPPORTED_ARCHITECTURES
 from ros_cross_compile.platform import SUPPORTED_ROS2_DISTROS
 from ros_cross_compile.platform import SUPPORTED_ROS_DISTROS
-from ros_cross_compile.sysroot_creator import create_workspace_sysroot_image
+from ros_cross_compile.sysroot_creator import CreateSysrootStage
 from ros_cross_compile.sysroot_creator import prepare_docker_build_environment
 
 logging.basicConfig(level=logging.INFO)
@@ -167,7 +167,7 @@ def cross_compile_pipeline(
         default_docker_dir=sysroot_build_context,
         colcon_defaults_file=args.colcon_defaults)
 
-    stages = [DependenciesStage()]
+    stages = [DependenciesStage(), CreateSysrootStage(), DockerBuildStage()]
     customizations = PipelineStageConfigOptions(
         args.skip_rosdep_collection,
         skip_rosdep_keys,
@@ -178,9 +178,6 @@ def cross_compile_pipeline(
     for stage in stages:
         with data_collector.timer('cross_compile_{}'.format(stage.name)):
             stage(platform, docker_client, ros_workspace_dir, customizations)
-
-    create_workspace_sysroot_image(docker_client, platform)
-    run_emulated_docker_build(docker_client, platform, ros_workspace_dir)
 
 
 def main():


### PR DESCRIPTION
Add the stages implemented in #231 to the pipeline runner implemented in #230 . Also move the name property from each subclass to the parent class (PipelineStage).

Signed-off-by: Siddharth Gollapudi <sgollapu@amazon.com>