### PR TITLE
Implement option to add custom filename

### DIFF
--- a/ros_cross_compile/data_collector.py
+++ b/ros_cross_compile/data_collector.py
@@ -15,7 +15,6 @@
 """Classes for time series data collection and writing said data to a file."""
 
 from contextlib import contextmanager
-from datetime import datetime
 from enum import Enum
 import json
 from pathlib import Path
@@ -68,7 +67,7 @@ class DataWriter:
     """Provides an interface to write collected data to a file."""
 
     def __init__(self, ros_workspace_dir: Path,
-                 output_file: Path = Path(datetime.now().strftime('%s') + '.json')):
+                 output_file):
         """Configure path for writing data."""
         self._write_path = Path(str(ros_workspace_dir)) / Path(INTERNALS_DIR) / Path('metrics')
         self._write_path.mkdir(parents=True, exist_ok=True)

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -17,6 +17,7 @@
 """Executable for cross-compiling ROS and ROS 2 packages."""
 
 import argparse
+from datetime import datetime
 import logging
 from pathlib import Path
 import sys
@@ -141,6 +142,15 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         default=[],
         nargs='+',
         help='Skip specified rosdep keys when collecting dependencies for the workspace.')
+    parser.add_argument(
+        '--custom-metric-file',
+        required=False,
+        default='{}.json'.format(datetime.now().strftime('%s')),
+        type=str,
+        help='Provide a filename to store the collected metrics. If no name is provided, '
+             'then the filename will be the current time in UNIX Epoch format. In addition, '
+             'the filename must include the JSON file extension. '
+    )
 
     return parser.parse_args(args)
 
@@ -185,7 +195,7 @@ def main():
     args = parse_args(sys.argv[1:])
     ros_workspace_dir = _resolve_ros_workspace(args.ros_workspace)
     data_collector = DataCollector()
-    data_writer = DataWriter(ros_workspace_dir)
+    data_writer = DataWriter(ros_workspace_dir, args.custom_metric_file)
 
     try:
         with data_collector.timer('cross_compile_end_to_end'):

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -148,8 +148,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         default='{}.json'.format(datetime.now().strftime('%s')),
         type=str,
         help='Provide a filename to store the collected metrics. If no name is provided, '
-             'then the filename will be the current time in UNIX Epoch format. In addition, '
-             'the filename must include the JSON file extension. '
+             'then the filename will be the current time in UNIX Epoch format. '
     )
 
     return parser.parse_args(args)

--- a/test/test_data_collector.py
+++ b/test/test_data_collector.py
@@ -89,7 +89,7 @@ def test_data_writing(tmp_path):
     test_collector.add_datum(test_datum_a)
     test_collector.add_datum(test_datum_b)
 
-    test_writer = DataWriter(tmp_path)
+    test_writer = DataWriter(tmp_path, 'test.json')
 
     test_writer.write(test_collector)
 


### PR DESCRIPTION
Specifically allows the user to specify a filename for storing the collected time-series data.

Resolves #210 
Signed-off-by: Siddharth Gollapudi <sgollapu@amazon.com>