### PR TITLE
Implement collection of docker image sizes

### DIFF
--- a/ros_cross_compile/builders.py
+++ b/ros_cross_compile/builders.py
@@ -15,6 +15,7 @@ import logging
 import os
 from pathlib import Path
 
+from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.pipeline_stages import PipelineStage
 from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
@@ -60,5 +61,6 @@ class DockerBuildStage(PipelineStage):
         super().__init__('run_emulated_docker_build')
 
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
-                 pipeline_stage_config_options: PipelineStageConfigOptions):
+                 pipeline_stage_config_options: PipelineStageConfigOptions,
+                 data_collector: DataCollector):
         run_emulated_docker_build(docker_client, platform, ros_workspace_dir)

--- a/ros_cross_compile/data_collector.py
+++ b/ros_cross_compile/data_collector.py
@@ -64,6 +64,12 @@ class DataCollector:
                                 Units.Seconds.value, time.monotonic(), complete)
             self.add_datum(time_metric)
 
+    def add_size(self, name: str, size: int):
+        """Provide an interface to add collected Docker image sizes."""
+        size_metric = Datum('{}-size'.format(name), size,
+                            Units.Bytes.value, time.monotonic(), True)
+        self.add_datum(size_metric)
+
 
 class DataWriter:
     """Provides an interface to write collected data to a file."""

--- a/ros_cross_compile/data_collector.py
+++ b/ros_cross_compile/data_collector.py
@@ -22,7 +22,8 @@ from pathlib import Path
 import time
 from typing import Dict, List, NamedTuple, Union
 
-from ros_cross_compile.sysroot_creator import INTERNALS_DIR
+
+INTERNALS_DIR = 'cc_internals'
 
 
 Datum = NamedTuple('Datum', [('name', str),
@@ -59,7 +60,7 @@ class DataCollector:
             complete = True
         finally:
             elapsed = time.monotonic() - start
-            time_metric = Datum(name + '-time', elapsed,
+            time_metric = Datum('{}-time'.format(name), elapsed,
                                 Units.Seconds.value, time.monotonic(), complete)
             self.add_datum(time_metric)
 

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -15,11 +15,10 @@
 import logging
 import os
 from pathlib import Path
-import time
 from typing import List
 from typing import Optional
 
-from ros_cross_compile.data_collector import DataCollector, Datum, Units
+from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.pipeline_stages import PipelineStage
 from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
@@ -32,7 +31,7 @@ logger = logging.getLogger('Rosdep Gatherer')
 
 CUSTOM_SETUP = '/usercustom/rosdep_setup'
 CUSTOM_DATA = '/usercustom/custom-data'
-IMG_NAME = 'ros_cross_compile:rosdep'
+_IMG_NAME = 'ros_cross_compile:rosdep'
 
 
 def rosdep_install_script(platform: Platform) -> Path:
@@ -60,10 +59,10 @@ def gather_rosdeps(
     """
     out_path = rosdep_install_script(platform)
 
-    logger.info('Building rosdep collector image: %s', IMG_NAME)
+    logger.info('Building rosdep collector image: %s', _IMG_NAME)
     docker_client.build_image(
         dockerfile_name='rosdep.Dockerfile',
-        tag=IMG_NAME,
+        tag=_IMG_NAME,
     )
 
     logger.info('Running rosdep collector image on workspace {}'.format(workspace))
@@ -76,7 +75,7 @@ def gather_rosdeps(
         volumes[custom_data_dir] = CUSTOM_DATA
 
     docker_client.run_container(
-        image_name=IMG_NAME,
+        image_name=_IMG_NAME,
         environment={
             'CUSTOM_SETUP': CUSTOM_SETUP,
             'OUT_PATH': str(out_path),
@@ -135,7 +134,5 @@ class DependenciesStage(PipelineStage):
                 custom_data_dir=pipeline_stage_config_options.custom_data_dir)
         assert_install_rosdep_script_exists(ros_workspace_dir, platform)
 
-        img_size = docker_client.get_image_size(IMG_NAME)
-        size_metric = Datum('{}-size'.format(self.name), img_size,
-                            Units.Bytes.value, time.monotonic(), True)
-        data_collector.add_datum(size_metric)
+        img_size = docker_client.get_image_size(_IMG_NAME)
+        data_collector.add_size(self.name, img_size)

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -15,9 +15,11 @@
 import logging
 import os
 from pathlib import Path
+import time
 from typing import List
 from typing import Optional
 
+from ros_cross_compile.data_collector import DataCollector, Datum, Units
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.pipeline_stages import PipelineStage
 from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
@@ -30,6 +32,7 @@ logger = logging.getLogger('Rosdep Gatherer')
 
 CUSTOM_SETUP = '/usercustom/rosdep_setup'
 CUSTOM_DATA = '/usercustom/custom-data'
+IMG_NAME = 'ros_cross_compile:rosdep'
 
 
 def rosdep_install_script(platform: Platform) -> Path:
@@ -57,11 +60,10 @@ def gather_rosdeps(
     """
     out_path = rosdep_install_script(platform)
 
-    image_name = 'ros_cross_compile:rosdep'
-    logger.info('Building rosdep collector image: %s', image_name)
+    logger.info('Building rosdep collector image: %s', IMG_NAME)
     docker_client.build_image(
         dockerfile_name='rosdep.Dockerfile',
-        tag=image_name,
+        tag=IMG_NAME,
     )
 
     logger.info('Running rosdep collector image on workspace {}'.format(workspace))
@@ -74,7 +76,7 @@ def gather_rosdeps(
         volumes[custom_data_dir] = CUSTOM_DATA
 
     docker_client.run_container(
-        image_name=image_name,
+        image_name=IMG_NAME,
         environment={
             'CUSTOM_SETUP': CUSTOM_SETUP,
             'OUT_PATH': str(out_path),
@@ -111,9 +113,12 @@ class DependenciesStage(PipelineStage):
         super().__init__('gather_rosdeps')
 
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
-                 pipeline_stage_config_options: PipelineStageConfigOptions):
+                 pipeline_stage_config_options: PipelineStageConfigOptions,
+                 data_collector: DataCollector):
         """
         Run the inspection and output the dependency installation script.
+
+        Also recovers the size of the docker image generated.
 
         :raises RuntimeError if the step was skipped when no dependency script has been
         previously generated
@@ -129,3 +134,8 @@ class DependenciesStage(PipelineStage):
                 custom_script=pipeline_stage_config_options.custom_script,
                 custom_data_dir=pipeline_stage_config_options.custom_data_dir)
         assert_install_rosdep_script_exists(ros_workspace_dir, platform)
+
+        img_size = docker_client.get_image_size(IMG_NAME)
+        size_metric = Datum('{}-size'.format(self.name), img_size,
+                            Units.Bytes.value, time.monotonic(), True)
+        data_collector.add_datum(size_metric)

--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -142,3 +142,6 @@ class DockerClient:
         if exit_code:
             raise docker.errors.ContainerError(
                 image_name, exit_code, '', image_name, 'See above ^')
+
+    def get_image_size(self, img_name: str) -> int:
+        return self._client.images.get(img_name).attrs['Size']

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -16,6 +16,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List, NamedTuple, Optional
 
+from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.platform import Platform
 
@@ -47,5 +48,6 @@ class PipelineStage(ABC):
 
     @abstractmethod
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
-                 customizations: PipelineStageConfigOptions):
+                 pipeline_stage_config_options: PipelineStageConfigOptions,
+                 data_collector: DataCollector):
         raise NotImplementedError

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -177,7 +177,7 @@ def cross_compile_pipeline(
 
     for stage in stages:
         with data_collector.timer('cross_compile_{}'.format(stage.name)):
-            stage(platform, docker_client, ros_workspace_dir, customizations)
+            stage(platform, docker_client, ros_workspace_dir, customizations, data_collector)
 
 
 def main():

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -17,8 +17,13 @@ import logging
 from pathlib import Path
 import platform as py_platform
 import shutil
+import time
 from typing import Optional
 
+from ros_cross_compile.data_collector import DataCollector
+from ros_cross_compile.data_collector import Datum
+from ros_cross_compile.data_collector import INTERNALS_DIR
+from ros_cross_compile.data_collector import Units
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.pipeline_stages import PipelineStage
 from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
@@ -26,8 +31,6 @@ from ros_cross_compile.platform import Platform
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-INTERNALS_DIR = 'cc_internals'
 
 
 def build_internals_dir(platform: Platform) -> Path:
@@ -135,5 +138,11 @@ class CreateSysrootStage(PipelineStage):
         super().__init__('create_workspace_sysroot_image')
 
     def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
-                 pipeline_stage_config_options: PipelineStageConfigOptions):
+                 pipeline_stage_config_options: PipelineStageConfigOptions,
+                 data_collector: DataCollector):
         create_workspace_sysroot_image(docker_client, platform)
+
+        img_size = docker_client.get_image_size(platform.sysroot_image_tag)
+        size_metric = Datum('{}-size'.format(self.name), img_size,
+                            Units.Bytes.value, time.monotonic(), True)
+        data_collector.add_datum(size_metric)

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -17,13 +17,10 @@ import logging
 from pathlib import Path
 import platform as py_platform
 import shutil
-import time
 from typing import Optional
 
 from ros_cross_compile.data_collector import DataCollector
-from ros_cross_compile.data_collector import Datum
 from ros_cross_compile.data_collector import INTERNALS_DIR
-from ros_cross_compile.data_collector import Units
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.pipeline_stages import PipelineStage
 from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
@@ -143,6 +140,4 @@ class CreateSysrootStage(PipelineStage):
         create_workspace_sysroot_image(docker_client, platform)
 
         img_size = docker_client.get_image_size(platform.sysroot_image_tag)
-        size_metric = Datum('{}-size'.format(self.name), img_size,
-                            Units.Bytes.value, time.monotonic(), True)
-        data_collector.add_datum(size_metric)
+        data_collector.add_size(self.name, img_size)

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -23,13 +23,15 @@ from ros_cross_compile.platform import Platform
 def test_emulated_docker_build():
     # Very simple smoke test to validate that all internal syntax is correct
     mock_docker_client = Mock()
+    mock_data_collector = Mock()
     platform = Platform('aarch64', 'ubuntu', 'eloquent')
 
     # a default set of customizations for the docker build stage
     customizations = PipelineStageConfigOptions(False, [], None, None, None)
     temp_stage = DockerBuildStage()
 
-    temp_stage(platform, mock_docker_client, Path('dummy_path'), customizations)
+    temp_stage(platform, mock_docker_client,
+               Path('dummy_path'), customizations, mock_data_collector)
 
     assert mock_docker_client.run_container.call_count == 1
 

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -17,6 +17,7 @@ import shutil
 import docker
 import pytest
 
+from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.dependencies import DependenciesStage
 from ros_cross_compile.dependencies import gather_rosdeps
 from ros_cross_compile.dependencies import rosdep_install_script
@@ -59,12 +60,13 @@ def test_dummy_ros2_pkg(tmpdir):
     client = DockerClient()
     platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
     out_script = ws / rosdep_install_script(platform)
+    test_collector = DataCollector()
 
     # a default set of customizations for the dependencies stage
     customizations = PipelineStageConfigOptions(False, [], None, None, None)
     temp_stage = DependenciesStage()
 
-    temp_stage(platform, client, ws, customizations)
+    temp_stage(platform, client, ws, customizations, test_collector)
 
     result = out_script.read_text()
     assert 'ros-dashing-ament-cmake' in result

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -85,13 +85,15 @@ def test_basic_sysroot_creation(tmpdir):
     # Very simple smoke test to validate that all internal syntax is correct
 
     mock_docker_client = Mock()
+    mock_data_collector = Mock()
     platform = Platform('aarch64', 'ubuntu', 'eloquent')
 
     # a default set of customizations for the docker build stage
     customizations = PipelineStageConfigOptions(False, [], None, None, None)
     temp_stage = CreateSysrootStage()
 
-    temp_stage(platform, mock_docker_client, Path('dummy_path'), customizations)
+    temp_stage(platform, mock_docker_client,
+               Path('dummy_path'), customizations, mock_data_collector)
     assert mock_docker_client.build_image.call_count == 1
 
 


### PR DESCRIPTION
Some of the stages of the cross compile pipeline make use of a Docker image. For "research" purposes, we want to be able to get the size of these docker images.

Resolves #208 
Resolves #209 

Signed-off-by: Siddharth Gollapudi <sgollapu@amazon.com>