### PR TITLE
Compatibility with newer versions of docker

### DIFF
--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -136,6 +136,9 @@ class DockerClient:
             container.stop()
             container.remove()
 
+        if docker.version_info[0] >= 3:
+            exit_code = exit_code['StatusCode']
+
         if exit_code:
             raise docker.errors.ContainerError(
                 image_name, exit_code, '', image_name, 'See above ^')


### PR DESCRIPTION
See also: https://docker-py.readthedocs.io/en/stable/change-log.html

(Ctrl+F 'breaking')