### PR TITLE
Change && to || fix if statement logic

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -49,12 +49,12 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ secrets.AWS_REGION }}
     - uses: ros-tooling/action-cloudwatch-metrics@0.0.5
-      if: ${{ matrix.target_arch != 'armhf' && matrix.rosdistro != 'foxy' }}
+      if: ${{ matrix.target_arch != 'armhf' || matrix.rosdistro != 'foxy' }}
       with:
         metric-data: "${{ env.METRICS_OUT_DIR }}/${{ matrix.target_arch }}_${{ matrix.target_os }}_${{ matrix.rosdistro }}_a"
         namespace: "CrossCompileMetrics"
     - uses: ros-tooling/action-cloudwatch-metrics@0.0.5
-      if: ${{ matrix.target_arch != 'armhf' && matrix.rosdistro != 'foxy' }}
+      if: ${{ matrix.target_arch != 'armhf' || matrix.rosdistro != 'foxy' }}
       with:
         metric-data: "${{ env.METRICS_OUT_DIR }}/${{ matrix.target_arch }}_${{ matrix.target_os }}_${{ matrix.rosdistro }}_b"
         namespace: "CrossCompileMetrics"


### PR DESCRIPTION
The if statement that checks if there is a valid metrics json for a given OS/Architecture/ROS Distro combination did not work. This fixes it.

Signed-off-by: Siddharth Gollapudi <sgollapu@amazon.com>