### PR TITLE
Generic way to skip pipeline stages

### DIFF
--- a/ros_cross_compile/builders.py
+++ b/ros_cross_compile/builders.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.pipeline_stages import PipelineStage
-from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
+from ros_cross_compile.pipeline_stages import PipelineStageOptions
 from ros_cross_compile.platform import Platform
 
 logging.basicConfig(level=logging.INFO)
@@ -50,7 +50,7 @@ def run_emulated_docker_build(
     )
 
 
-class DockerBuildStage(PipelineStage):
+class EmulatedDockerBuildStage(PipelineStage):
     """
     This stage spins up a docker container and runs the emulated build with it.
 
@@ -58,9 +58,14 @@ class DockerBuildStage(PipelineStage):
     """
 
     def __init__(self):
-        super().__init__('run_emulated_docker_build')
+        super().__init__('emulated_build')
 
-    def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
-                 pipeline_stage_config_options: PipelineStageConfigOptions,
-                 data_collector: DataCollector):
+    def __call__(
+        self,
+        platform: Platform,
+        docker_client: DockerClient,
+        ros_workspace_dir: Path,
+        options: PipelineStageOptions,
+        data_collector: DataCollector
+    ):
         run_emulated_docker_build(docker_client, platform, ros_workspace_dir)

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -127,8 +127,6 @@ class CollectDependencyListStage(PipelineStage):
         :raises RuntimeError if the step was skipped when no dependency script has been
         previously generated
         """
-        # NOTE: Stage skipping will be handled more generically in the future;
-        # for now we handle this specific case internally to maintain the original API.
         gather_rosdeps(
             docker_client=docker_client,
             platform=platform,

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -100,7 +100,7 @@ def assert_install_rosdep_script_exists(
     return True
 
 
-class DependenciesStage(PipelineStage):
+class CollectDependencyListStage(PipelineStage):
     """
     This stage determines what external dependencies are needed for building.
 
@@ -124,14 +124,13 @@ class DependenciesStage(PipelineStage):
         """
         # NOTE: Stage skipping will be handled more generically in the future;
         # for now we handle this specific case internally to maintain the original API.
-        if not pipeline_stage_config_options.skip_rosdep_collection:
-            gather_rosdeps(
-                docker_client=docker_client,
-                platform=platform,
-                workspace=ros_workspace_dir,
-                skip_rosdep_keys=pipeline_stage_config_options.skip_rosdep_keys,
-                custom_script=pipeline_stage_config_options.custom_script,
-                custom_data_dir=pipeline_stage_config_options.custom_data_dir)
+        gather_rosdeps(
+            docker_client=docker_client,
+            platform=platform,
+            workspace=ros_workspace_dir,
+            skip_rosdep_keys=pipeline_stage_config_options.skip_rosdep_keys,
+            custom_script=pipeline_stage_config_options.custom_script,
+            custom_data_dir=pipeline_stage_config_options.custom_data_dir)
         assert_install_rosdep_script_exists(ros_workspace_dir, platform)
 
         img_size = docker_client.get_image_size(_IMG_NAME)

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -21,7 +21,7 @@ from typing import Optional
 from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.pipeline_stages import PipelineStage
-from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
+from ros_cross_compile.pipeline_stages import PipelineStageOptions
 from ros_cross_compile.platform import Platform
 from ros_cross_compile.sysroot_creator import build_internals_dir
 
@@ -111,9 +111,14 @@ class CollectDependencyListStage(PipelineStage):
     def __init__(self):
         super().__init__('gather_rosdeps')
 
-    def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
-                 pipeline_stage_config_options: PipelineStageConfigOptions,
-                 data_collector: DataCollector):
+    def __call__(
+        self,
+        platform: Platform,
+        docker_client: DockerClient,
+        ros_workspace_dir: Path,
+        options: PipelineStageOptions,
+        data_collector: DataCollector
+    ):
         """
         Run the inspection and output the dependency installation script.
 
@@ -128,9 +133,9 @@ class CollectDependencyListStage(PipelineStage):
             docker_client=docker_client,
             platform=platform,
             workspace=ros_workspace_dir,
-            skip_rosdep_keys=pipeline_stage_config_options.skip_rosdep_keys,
-            custom_script=pipeline_stage_config_options.custom_script,
-            custom_data_dir=pipeline_stage_config_options.custom_data_dir)
+            skip_rosdep_keys=options.skip_rosdep_keys,
+            custom_script=options.custom_script,
+            custom_data_dir=options.custom_data_dir)
         assert_install_rosdep_script_exists(ros_workspace_dir, platform)
 
         img_size = docker_client.get_image_size(_IMG_NAME)

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -49,7 +49,12 @@ class PipelineStage(ABC):
         return self._name
 
     @abstractmethod
-    def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
-                 pipeline_stage_config_options: PipelineStageConfigOptions,
-                 data_collector: DataCollector):
+    def __call__(
+        self,
+        platform: Platform,
+        docker_client: DockerClient,
+        ros_workspace_dir: Path,
+        pipeline_stage_config_options: PipelineStageOptions,
+        data_collector: DataCollector
+    ):
         raise NotImplementedError

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -27,12 +27,14 @@ A NamedTuple that collects the customizations for each stage passed in by the us
 As such, the documentation for each customization can be found by looking at the
 argparse options in ros_cross_compile.py.
 """
-PipelineStageConfigOptions = NamedTuple('PipelineStageConfigOptions',
-                                        [('skip_rosdep_collection', bool),
-                                         ('skip_rosdep_keys', List[str]),
-                                         ('custom_script', Optional[Path]),
-                                         ('custom_data_dir', Optional[Path]),
-                                         ('custom_setup_script', Optional[Path])])
+PipelineStageOptions = NamedTuple(
+    'PipelineStageOptions',
+    [
+        ('skip_rosdep_keys', List[str]),
+        ('custom_script', Optional[Path]),
+        ('custom_data_dir', Optional[Path]),
+        ('custom_setup_script', Optional[Path]),
+    ])
 
 
 class PipelineStage(ABC):

--- a/ros_cross_compile/pipeline_stages.py
+++ b/ros_cross_compile/pipeline_stages.py
@@ -54,7 +54,7 @@ class PipelineStage(ABC):
         platform: Platform,
         docker_client: DockerClient,
         ros_workspace_dir: Path,
-        pipeline_stage_config_options: PipelineStageOptions,
+        options: PipelineStageOptions,
         data_collector: DataCollector
     ):
         raise NotImplementedError

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -24,10 +24,10 @@ import sys
 from typing import List
 from typing import Optional
 
-from ros_cross_compile.builders import DockerBuildStage
+from ros_cross_compile.builders import EmulatedDockerBuildStage
 from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.data_collector import DataWriter
-from ros_cross_compile.dependencies import DependenciesStage
+from ros_cross_compile.dependencies import CollectDependencyListStage
 from ros_cross_compile.docker_client import DEFAULT_COLCON_DEFAULTS_FILE
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
@@ -40,6 +40,12 @@ from ros_cross_compile.sysroot_creator import prepare_docker_build_environment
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+stages = [
+    CollectDependencyListStage(),
+    CreateSysrootStage(),
+    EmulatedDockerBuildStage(),
+]
 
 
 def _path_if(path: Optional[str] = None) -> Optional[Path]:
@@ -131,13 +137,6 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         help='Relative path within the workspace to a file that provides colcon arguments. '
              'See "Package Selection and Build Customization" in README.md for more details.')
     parser.add_argument(
-        '--skip-rosdep-collection',
-        action='store_true',
-        required=False,
-        help='Skip querying rosdep for dependencies. This is intended to save time when running '
-             'repeatedly during development, but has undefined behavior if the dependencies of '
-             'the workspace have changed since the last time they were collected.')
-    parser.add_argument(
         '--skip-rosdep-keys',
         default=[],
         nargs='+',
@@ -154,6 +153,12 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         action='store_true',
         required=False,
         help='All collected metrics will be printed to stdout via the logging framework.')
+    parser.add_argument(
+        '--skip-steps',
+        nargs='+',
+        choices=[stage.name for stage in stages],
+        default=[],
+        help='Skip these steps')
 
     return parser.parse_args(args)
 
@@ -179,17 +184,16 @@ def cross_compile_pipeline(
         default_docker_dir=sysroot_build_context,
         colcon_defaults_file=args.colcon_defaults)
 
-    stages = [DependenciesStage(), CreateSysrootStage(), DockerBuildStage()]
-    customizations = PipelineStageConfigOptions(
-        args.skip_rosdep_collection,
+    customizations = PipelineStageOptions(
         skip_rosdep_keys,
         custom_rosdep_script,
         custom_data_dir,
         custom_setup_script)
 
     for stage in stages:
-        with data_collector.timer('{}'.format(stage.name)):
-            stage(platform, docker_client, ros_workspace_dir, customizations, data_collector)
+        if stage.name not in args.skip_steps:
+            with data_collector.timer('{}'.format(stage.name)):
+                stage(platform, docker_client, ros_workspace_dir, customizations, data_collector)
 
 
 def main():

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -23,7 +23,7 @@ from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.data_collector import INTERNALS_DIR
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.pipeline_stages import PipelineStage
-from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
+from ros_cross_compile.pipeline_stages import PipelineStageOptions
 from ros_cross_compile.platform import Platform
 
 logging.basicConfig(level=logging.INFO)
@@ -132,11 +132,16 @@ class CreateSysrootStage(PipelineStage):
     """
 
     def __init__(self):
-        super().__init__('create_workspace_sysroot_image')
+        super().__init__('sysroot')
 
-    def __call__(self, platform: Platform, docker_client: DockerClient, ros_workspace_dir: Path,
-                 pipeline_stage_config_options: PipelineStageConfigOptions,
-                 data_collector: DataCollector):
+    def __call__(
+        self,
+        platform: Platform,
+        docker_client: DockerClient,
+        ros_workspace_dir: Path,
+        options: PipelineStageOptions,
+        data_collector: DataCollector
+    ):
         create_workspace_sysroot_image(docker_client, platform)
 
         img_size = docker_client.get_image_size(platform.sysroot_image_tag)

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -14,10 +14,10 @@
 from pathlib import Path
 from unittest.mock import Mock
 
-from ros_cross_compile.builders import DockerBuildStage
-from ros_cross_compile.builders import run_emulated_docker_build
-from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
+from ros_cross_compile.builders import EmulatedDockerBuildStage
 from ros_cross_compile.platform import Platform
+
+from .utilities import default_pipeline_options
 
 
 def test_emulated_docker_build():
@@ -26,21 +26,17 @@ def test_emulated_docker_build():
     mock_data_collector = Mock()
     platform = Platform('aarch64', 'ubuntu', 'eloquent')
 
-    # a default set of customizations for the docker build stage
-    customizations = PipelineStageConfigOptions(False, [], None, None, None)
-    temp_stage = DockerBuildStage()
-
-    temp_stage(platform, mock_docker_client,
-               Path('dummy_path'), customizations, mock_data_collector)
+    stage = EmulatedDockerBuildStage()
+    stage(
+        platform,
+        mock_docker_client,
+        Path('dummy_path'),
+        default_pipeline_options(),
+        mock_data_collector)
 
     assert mock_docker_client.run_container.call_count == 1
 
 
 def test_docker_build_stage_creation():
-    temp_stage = DockerBuildStage()
+    temp_stage = EmulatedDockerBuildStage()
     assert temp_stage
-
-
-def test_docker_build_stage_name():
-    temp_stage = DockerBuildStage()
-    assert temp_stage._name == run_emulated_docker_build.__name__

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -18,13 +18,13 @@ import docker
 import pytest
 
 from ros_cross_compile.data_collector import DataCollector
-from ros_cross_compile.dependencies import DependenciesStage
+from ros_cross_compile.dependencies import CollectDependencyListStage
 from ros_cross_compile.dependencies import gather_rosdeps
 from ros_cross_compile.dependencies import rosdep_install_script
 from ros_cross_compile.docker_client import DockerClient
-from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
 from ros_cross_compile.platform import Platform
 
+from .utilities import default_pipeline_options
 from .utilities import uses_docker
 
 
@@ -62,11 +62,8 @@ def test_dummy_ros2_pkg(tmpdir):
     out_script = ws / rosdep_install_script(platform)
     test_collector = DataCollector()
 
-    # a default set of customizations for the dependencies stage
-    customizations = PipelineStageConfigOptions(False, [], None, None, None)
-    temp_stage = DependenciesStage()
-
-    temp_stage(platform, client, ws, customizations, test_collector)
+    stage = CollectDependencyListStage()
+    stage(platform, client, ws, default_pipeline_options(), test_collector)
 
     result = out_script.read_text()
     assert 'ros-dashing-ament-cmake' in result
@@ -214,10 +211,10 @@ def test_dummy_skip_rosdep_multiple_keys_pkg(tmpdir):
 
 
 def test_dependencies_stage_creation():
-    temp_stage = DependenciesStage()
+    temp_stage = CollectDependencyListStage()
     assert temp_stage
 
 
 def test_dependencies_stage_name():
-    temp_stage = DependenciesStage()
+    temp_stage = CollectDependencyListStage()
     assert temp_stage._name == gather_rosdeps.__name__

--- a/test/test_pipeline_stages.py
+++ b/test/test_pipeline_stages.py
@@ -14,10 +14,13 @@
 
 from pathlib import Path
 
-from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
+from ros_cross_compile.pipeline_stages import PipelineStageOptions
 
 
 def test_config_tuple_creation():
-    test_options = PipelineStageConfigOptions(True, ['abc', 'def'], Path('./'),
-                                              Path('./'), Path('./'))
+    test_options = PipelineStageOptions(
+        skip_rosdeps=['abc', 'def'],
+        custom_script=Path('./'),
+        custom_data_dir=Path('./'),
+        custom_setup_script=Path('./'))
     assert test_options

--- a/test/test_pipeline_stages.py
+++ b/test/test_pipeline_stages.py
@@ -19,7 +19,7 @@ from ros_cross_compile.pipeline_stages import PipelineStageOptions
 
 def test_config_tuple_creation():
     test_options = PipelineStageOptions(
-        skip_rosdeps=['abc', 'def'],
+        skip_rosdep_keys=['abc', 'def'],
         custom_script=Path('./'),
         custom_data_dir=Path('./'),
         custom_setup_script=Path('./'))

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -24,7 +24,6 @@ from unittest.mock import patch
 import pytest
 
 from ros_cross_compile.platform import Platform
-from ros_cross_compile.sysroot_creator import create_workspace_sysroot_image
 from ros_cross_compile.sysroot_creator import CreateSysrootStage
 from ros_cross_compile.sysroot_creator import prepare_docker_build_environment
 from ros_cross_compile.sysroot_creator import setup_emulator
@@ -102,8 +101,3 @@ def test_basic_sysroot_creation(tmpdir):
 def test_create_sysroot_stage_creation():
     temp_stage = CreateSysrootStage()
     assert temp_stage
-
-
-def test_create_sysroot_stage_name():
-    temp_stage = CreateSysrootStage()
-    assert temp_stage._name == create_workspace_sysroot_image.__name__

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -23,12 +23,13 @@ from unittest.mock import patch
 
 import pytest
 
-from ros_cross_compile.pipeline_stages import PipelineStageConfigOptions
 from ros_cross_compile.platform import Platform
 from ros_cross_compile.sysroot_creator import create_workspace_sysroot_image
 from ros_cross_compile.sysroot_creator import CreateSysrootStage
 from ros_cross_compile.sysroot_creator import prepare_docker_build_environment
 from ros_cross_compile.sysroot_creator import setup_emulator
+
+from .utilities import default_pipeline_options
 
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -88,12 +89,13 @@ def test_basic_sysroot_creation(tmpdir):
     mock_data_collector = Mock()
     platform = Platform('aarch64', 'ubuntu', 'eloquent')
 
-    # a default set of customizations for the docker build stage
-    customizations = PipelineStageConfigOptions(False, [], None, None, None)
-    temp_stage = CreateSysrootStage()
-
-    temp_stage(platform, mock_docker_client,
-               Path('dummy_path'), customizations, mock_data_collector)
+    stage = CreateSysrootStage()
+    stage(
+        platform,
+        mock_docker_client,
+        Path('dummy_path'),
+        default_pipeline_options(),
+        mock_data_collector)
     assert mock_docker_client.build_image.call_count == 1
 
 

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -17,6 +17,8 @@ import platform
 
 import pytest
 
+from ros_cross_compile.pipeline_stages import PipelineStageOptions
+
 
 def uses_docker(func):
     """Decorate test to be skipped on platforms that don't have Docker for testing."""
@@ -28,3 +30,11 @@ def uses_docker(func):
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
     return wrapper
+
+
+def default_pipeline_options() -> PipelineStageOptions:
+    return PipelineStageOptions(
+        skip_rosdep_keys=[],
+        custom_script=None,
+        custom_data_dir=None,
+        custom_setup_script=None)


### PR DESCRIPTION
This allows us to remove the "skip-rosdep-collection" really specific option, in favor of a more generic one.

To do this, I needed to define the pipeline stages at a scope where the argument parser can read them. As part of the usability for this, give the stages shorter names. While changing the Options interface, make its naming conventions a little less redundant.

This will increase the iterative development usability and configurability of some upcoming changes, which split out the current CreateSysrootStage into two separate stages, CreateSysroot and CreateBuildEnvironment - as well as a new stage that will come at the end, PackageRuntimeEnvironment