### PR TITLE
Update linter URI for latest pip versions (fixes action CI)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ envlist = py37
 
 [testenv]
 deps =
-    git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament_copyright-0.8.1&subdirectory=ament_copyright
-    git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament_flake8-0.8.1&subdirectory=ament_flake8
-    git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament_lint-0.8.1&subdirectory=ament_lint
-    git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament_mypy-0.8.1&subdirectory=ament_mypy
-    git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament_pep257-0.8.1&subdirectory=ament_pep257
+    git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament-copyright&subdirectory=ament_copyright
+    git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament-flake8&subdirectory=ament_flake8
+    git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament-lint&subdirectory=ament_lint
+    git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament-mypy&subdirectory=ament_mypy
+    git+https://github.com/ament/ament_lint.git@0.8.1#egg=ament-pep257&subdirectory=ament_pep257
     flake8<3.8
     flake8-blind-except
     flake8-builtins


### PR DESCRIPTION
The latest release of pip3 no longer accepts this URI format. It had been printing warnings for a long time and this last release finally broke.