### PR TITLE
Add custom post-build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,37 @@ add-apt-repository ppa:rpi-distro/ppa
 apt-get install -y pigpio
 ```
 
+### Custom post-build script
+
+You may want to perform arbitrary post-processing on your build outputs, in the event of a sucessful build - use `--custom-post-build-script` for this.
+
+Keep in mind
+It is run at the root of the built workspace.
+
+Following is an example setup that allows a user to run [colcon bundle](https://github.com/colcon/colcon-bundle) to create a portable bundle of the cross-compiled application.
+
+here  is the `--custom-setup-script` script
+
+```bash
+#! /bin/bash
+set -eux
+pip3 install -U colcon-ros-bundle
+```
+
+Then, in the `--custom-post-build-script`:
+
+```bash
+#!/bin/bash
+set -eux
+colcon bundle \
+  --build-base build_"${TARGET_ARCH}" \
+  --install-base install_"${TARGET_ARCH}" \
+  --bundle-base bundle_"${TARGET_ARCH}"
+```
+
+Now, after the build completes, you should see the bundle outputs in the workspace directory.
+
+
 ### Custom data directory
 
 Your custom setup or rosdep script (see preceding sections) may need some data that is not otherwise accessible.

--- a/README.md
+++ b/README.md
@@ -173,26 +173,34 @@ It is run at the root of the built workspace.
 
 Following is an example setup that allows a user to run [colcon bundle](https://github.com/colcon/colcon-bundle) to create a portable bundle of the cross-compiled application.
 
-here  is the `--custom-setup-script` script
-
-```bash
-#! /bin/bash
-set -eux
-pip3 install -U colcon-ros-bundle
-```
-
-Then, in the `--custom-post-build-script`:
+Here are the contents of `./postbuild.sh`
 
 ```bash
 #!/bin/bash
 set -eux
+
+apt-get update
+apt-get install -y wget
+wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+
+apt-get install -y python3-apt
+pip3 install -u setuptools pip
+pip3 install -U colcon-ros-bundle
+
 colcon bundle \
   --build-base build_"${TARGET_ARCH}" \
   --install-base install_"${TARGET_ARCH}" \
   --bundle-base bundle_"${TARGET_ARCH}"
 ```
 
-Now, after the build completes, you should see the bundle outputs in the workspace directory.
+Now, run
+
+```
+ros_cross_compile /path/to/my/workspace --arch aarch64 --os ubuntu \
+  --custom-post-build-script ./postbuild.sh
+```
+
+After the build completes, you should see the bundle outputs in `bundle_aarch64`
 
 
 ### Custom data directory

--- a/README.md
+++ b/README.md
@@ -167,9 +167,7 @@ apt-get install -y pigpio
 ### Custom post-build script
 
 You may want to perform arbitrary post-processing on your build outputs, in the event of a sucessful build - use `--custom-post-build-script` for this.
-
-Keep in mind
-It is run at the root of the built workspace.
+Keep in mind that it is run at the root of the built workspace.
 
 Following is an example setup that allows a user to run [colcon bundle](https://github.com/colcon/colcon-bundle) to create a portable bundle of the cross-compiled application.
 

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -17,3 +17,6 @@ set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \
   --build-base build_"${TARGET_ARCH}" \
   --install-base install_"${TARGET_ARCH}"
+
+# Runs user-provided post-build logic (file is present and empty if it wasn't specified)
+/user-custom-post-build

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -99,4 +99,6 @@ RUN colcon mixin add cc_mixin file://$(pwd)/mixins/index.yaml && colcon mixin up
 # In case the workspace did not actually install any dependencies, add these for uniformity
 COPY build_workspace.sh /root
 WORKDIR /ros_ws
+COPY user-custom-post-build /
+RUN chmod +x /user-custom-post-build
 ENTRYPOINT ["/root/build_workspace.sh"]

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -118,11 +118,19 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         required=False,
         default=None,
         type=str,
-        help='Provide a path to a shell script that will be executed in the sysroot container '
+        help='Provide a path to a shell script that will be executed in the build container '
              'right before running "rosdep install" for your ROS workspace. This allows for '
              'adding extra apt sources that rosdep may not handle, or other arbitrary setup that '
              'is specific to your application build. See the section on "Custom Setup Script" '
              'in README.md for more details.')
+    parser.add_argument(
+        '--custom-post-build-script',
+        required=False,
+        default=None,
+        type=str,
+        help='Provide a path to a shell script that will be executed in the build container '
+             'after the build successfully completes. '
+             'See "Custom post-build script" in README.md for more information.')
     parser.add_argument(
         '--custom-data-dir',
         required=False,
@@ -184,11 +192,13 @@ def cross_compile_pipeline(
     custom_data_dir = _path_if(args.custom_data_dir)
     custom_rosdep_script = _path_if(args.custom_rosdep_script)
     custom_setup_script = _path_if(args.custom_setup_script)
+    custom_post_build_script = _path_if(args.custom_post_build_script)
 
     sysroot_build_context = prepare_docker_build_environment(
         platform=platform,
         ros_workspace=ros_workspace_dir,
         custom_setup_script=custom_setup_script,
+        custom_post_build_script=custom_post_build_script,
         custom_data_dir=custom_data_dir)
     docker_client = DockerClient(
         args.sysroot_nocache,

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -138,10 +138,10 @@ def test_custom_post_build_script(tmpdir):
     ros_workspace = Path(str(tmpdir)) / 'ros_ws'
     _touch_anywhere(ros_workspace / rosdep_install_script(platform))
     post_build_script = ros_workspace / 'post_build'
-    post_build_script.write_text(f"""
+    post_build_script.write_text("""
     #!/bin/bash
-    echo "success" > {created_filename}
-    """)
+    echo "success" > {}
+    """.format(created_filename))
     build_context = prepare_docker_build_environment(
         platform,
         ros_workspace,


### PR DESCRIPTION
Implements #271

This adds another customizable script hook, this time after the build has completed, allowing the user to postprocess their build outputs in the build environment.

The unit test is for a fairly simple case, the colcon-bundle example in the README has been tested manually but seems overkill for a test.