### PR TITLE
chown build outputs even if build fails

### DIFF
--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euxo pipefail
 
+cleanup() {
+  chown -R "${OWNER_USER}" .
+}
+
+trap 'cleanup' EXIT
+
 mkdir -p /opt/ros/"${ROS_DISTRO}"
 touch /opt/ros/"${ROS_DISTRO}"/setup.bash
 
@@ -11,4 +17,3 @@ set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \
   --build-base build_"${TARGET_ARCH}" \
   --install-base install_"${TARGET_ARCH}"
-chown -R "${OWNER_USER}" .


### PR DESCRIPTION
Fixes #153
Depends on #276

Use an exit hook in the bash building script to make sure that everything in the workspace is owned by the calling user, rather than by root. Add a test that fails before the change