### PR TITLE
Add and enable a pytest for the emulated build stage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,25 +34,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7]
-    container:
-      image: ubuntu:bionic
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
-        # Mount the source workspace as a volume.
-        # This fixes the tests that depend on Docker for Docker containers.
-        # The reason being is that Docker in Docker commonly works by spinning up sibling containers.
-        # This makes it so any file/folder created within the parent Docker container is not accessible in the child.
-        # Tox creates a temp directory at cross_compile/test/.tox
-        # By mounting the source as a volume, all files created during test will be written back to host and
-        # will be accessible once the child Docker container starts
-        - /__w/cross_compile/cross_compile:/__w/cross_compile/cross_compile
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Install dependencies
-      run: |
-        apt-get update
-        apt-get install -y git qemu-user-static python3 python3-pip
+      run: sudo apt-get update && sudo apt-get install -y qemu-user-static
     - uses: actions/setup-python@v2.1.4
       with:
         python-version: ${{ matrix.python-version }}

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -64,8 +64,8 @@ def setup_emulator(arch: str, output_dir: Path) -> None:
 def prepare_docker_build_environment(
     platform: Platform,
     ros_workspace: Path,
-    custom_setup_script: Optional[Path],
-    custom_data_dir: Optional[Path],
+    custom_setup_script: Optional[Path] = None,
+    custom_data_dir: Optional[Path] = None,
 ) -> Path:
     """
     Prepare the directory for the sysroot.Docker build context.

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -11,13 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import getpass
 from pathlib import Path
+from typing import NamedTuple
 from unittest.mock import Mock
 
+import pytest
+
 from ros_cross_compile.builders import EmulatedDockerBuildStage
+from ros_cross_compile.data_collector import DataCollector
+from ros_cross_compile.dependencies import rosdep_install_script
+from ros_cross_compile.docker_client import DockerClient
+from ros_cross_compile.pipeline_stages import PipelineStageOptions
 from ros_cross_compile.platform import Platform
+from ros_cross_compile.sysroot_creator import CreateSysrootStage
+from ros_cross_compile.sysroot_creator import prepare_docker_build_environment
 
 from .utilities import default_pipeline_options
+from .utilities import uses_docker
+
+
+def _touch_anywhere(path: Path):
+    """Make the parent directories of a given path and then touch the file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
 
 
 def test_emulated_docker_build():
@@ -40,3 +57,43 @@ def test_emulated_docker_build():
 def test_docker_build_stage_creation():
     temp_stage = EmulatedDockerBuildStage()
     assert temp_stage
+
+
+BuildableEnv = NamedTuple('BuildableEnv', [
+    ('platform', Platform),
+    ('docker', DockerClient),
+    ('ros_workspace', Path),
+    ('options', PipelineStageOptions),
+    ('data_collector', DataCollector)
+])
+
+
+@pytest.fixture
+def buildable_env(tmpdir):
+    platform = Platform('aarch64', 'ubuntu', 'foxy')
+    ros_workspace = Path(str(tmpdir)) / 'ros_ws'
+    _touch_anywhere(ros_workspace / rosdep_install_script(platform))
+    build_context = prepare_docker_build_environment(platform, ros_workspace)
+    docker = DockerClient(disable_cache=False, default_docker_dir=build_context)
+    options = default_pipeline_options()
+    data_collector = DataCollector()
+
+    CreateSysrootStage()(
+        platform, docker, ros_workspace, options, data_collector)
+
+    return BuildableEnv(platform, docker, ros_workspace, options, data_collector)
+
+
+@uses_docker
+def test_build_ownership_on_success(buildable_env):
+    EmulatedDockerBuildStage()(
+        buildable_env.platform,
+        buildable_env.docker,
+        buildable_env.ros_workspace,
+        buildable_env.options,
+        buildable_env.data_collector)
+
+    # make sure all files are owned by the current user
+    user = getpass.getuser()
+    for p in buildable_env.ros_workspace.rglob('*'):
+        assert user == p.owner()

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -70,6 +70,7 @@ BuildableEnv = NamedTuple('BuildableEnv', [
 
 @pytest.fixture
 def buildable_env(tmpdir):
+    """Set up a temporary directory with everything needed to run the EmulatedDockerBuildStage."""
     platform = Platform('aarch64', 'ubuntu', 'foxy')
     ros_workspace = Path(str(tmpdir)) / 'ros_ws'
     _touch_anywhere(ros_workspace / rosdep_install_script(platform))

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,7 @@ deps =
     yamllint
 commands =
     pytest --basetemp="{envtmpdir}" --cov=ros_cross_compile --cov-report=xml test/ {posargs}
+
+[pytest]
+log_cli = true
+log_cli_level = DEBUG


### PR DESCRIPTION
The docker-in-docker situation for these pytests did not allow for qemu emulation - those runs failed for this test. So, make the test.yml Ubuntu environment the same as the e2e test.

This doesn't change any existing functionality, it only enables a new test for existing functionality.