### PR TITLE
Deprecate Eloquent

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         target_arch: [aarch64, armhf, x86_64]
         target_os: [ubuntu, debian]
-        rosdistro: [dashing, eloquent, foxy, melodic]
+        rosdistro: [dashing, foxy, melodic]
     env:
       METRICS_OUT_DIR: /tmp/collected_metrics
     steps:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool supports compiling a workspace for all combinations of the following:
 * Architecture: `armhf`, `aarch64`, `x86_64`
 * ROS Distro
   * ROS: `kinetic`, `melodic`
-  * ROS 2: `dashing`, `eloquent`, `foxy`
+  * ROS 2: `dashing`, `foxy`
 * OS: `Ubuntu`, `Debian`
 
 NOTE: ROS 2 supports Debian only as a Tier 3 platform.

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import getpass
+import logging
 from typing import NamedTuple
 from typing import Optional
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 ArchNameMapping = NamedTuple('ArchNameMapping', [('docker', str), ('qemu', str)])
 
@@ -28,6 +32,7 @@ SUPPORTED_ARCHITECTURES = tuple(ARCHITECTURE_NAME_MAP.keys())
 
 SUPPORTED_ROS2_DISTROS = ('dashing', 'eloquent', 'foxy')
 SUPPORTED_ROS_DISTROS = ('kinetic', 'melodic')
+EOL_DISTROS = {'eloquent'}
 
 ROSDISTRO_OS_MAP = {
     'kinetic': {
@@ -83,6 +88,12 @@ class Platform:
             self._ros_version = 'ros'
         else:
             raise ValueError('Unknown ROS distribution "{}" specified'.format(ros_distro))
+
+        if self.ros_distro in EOL_DISTROS:
+            logger.error(
+                'Targeted ROS distribution "{}" has reached End Of Life (EOL) '
+                '- there is no guarantee this build will continue working in the future'.format(
+                    self.ros_distro))
 
         os_map = ROSDISTRO_OS_MAP[self.ros_distro]
         if self.os_name not in os_map:

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -28,6 +28,7 @@ from ros_cross_compile.sysroot_creator import CreateSysrootStage
 from ros_cross_compile.sysroot_creator import prepare_docker_build_environment
 
 from .utilities import default_pipeline_options
+from .utilities import DEFAULT_TEST_DISTRO
 from .utilities import uses_docker
 
 
@@ -41,7 +42,7 @@ def test_emulated_docker_build():
     # Very simple smoke test to validate that all internal syntax is correct
     mock_docker_client = Mock()
     mock_data_collector = Mock()
-    platform = Platform('aarch64', 'ubuntu', 'eloquent')
+    platform = Platform('aarch64', 'ubuntu', DEFAULT_TEST_DISTRO)
 
     stage = EmulatedDockerBuildStage()
     stage(

--- a/test/test_platform.py
+++ b/test/test_platform.py
@@ -22,6 +22,8 @@ import pytest
 
 from ros_cross_compile.sysroot_creator import Platform
 
+from .utilities import DEFAULT_TEST_DISTRO
+
 
 @pytest.fixture
 def platform_config() -> Platform:
@@ -49,7 +51,7 @@ def test_platform_argument_validation():
 
 
 def test_construct_x86():
-    p = Platform('x86_64', 'ubuntu', 'eloquent')
+    p = Platform('x86_64', 'ubuntu', DEFAULT_TEST_DISTRO)
     assert p
 
 
@@ -70,22 +72,18 @@ def verify_base_docker_images(arch, os_name, rosdistro, image_name):
 def test_get_docker_base_image():
     """Test that the correct base docker image is used for all arguments."""
     verify_base_docker_images('aarch64', 'ubuntu', 'dashing', 'arm64v8/ubuntu:bionic')
-    verify_base_docker_images('aarch64', 'ubuntu', 'eloquent', 'arm64v8/ubuntu:bionic')
     verify_base_docker_images('aarch64', 'ubuntu', 'kinetic', 'arm64v8/ubuntu:xenial')
     verify_base_docker_images('aarch64', 'ubuntu', 'melodic', 'arm64v8/ubuntu:bionic')
 
     verify_base_docker_images('aarch64', 'debian', 'dashing', 'arm64v8/debian:stretch')
-    verify_base_docker_images('aarch64', 'debian', 'eloquent', 'arm64v8/debian:buster')
     verify_base_docker_images('aarch64', 'debian', 'kinetic', 'arm64v8/debian:jessie')
     verify_base_docker_images('aarch64', 'debian', 'melodic', 'arm64v8/debian:stretch')
 
     verify_base_docker_images('armhf', 'ubuntu', 'dashing', 'arm32v7/ubuntu:bionic')
-    verify_base_docker_images('armhf', 'ubuntu', 'eloquent', 'arm32v7/ubuntu:bionic')
     verify_base_docker_images('armhf', 'ubuntu', 'kinetic', 'arm32v7/ubuntu:xenial')
     verify_base_docker_images('armhf', 'ubuntu', 'melodic', 'arm32v7/ubuntu:bionic')
 
     verify_base_docker_images('armhf', 'debian', 'dashing', 'arm32v7/debian:stretch')
-    verify_base_docker_images('armhf', 'debian', 'eloquent', 'arm32v7/debian:buster')
     verify_base_docker_images('armhf', 'debian', 'kinetic', 'arm32v7/debian:jessie')
     verify_base_docker_images('armhf', 'debian', 'melodic', 'arm32v7/debian:stretch')
 

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -29,6 +29,7 @@ from ros_cross_compile.sysroot_creator import prepare_docker_build_environment
 from ros_cross_compile.sysroot_creator import setup_emulator
 
 from .utilities import default_pipeline_options
+from .utilities import DEFAULT_TEST_DISTRO
 
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -64,7 +65,7 @@ def test_run_twice(tmpdir):
 
 
 def test_prepare_docker_build_with_user_custom(tmpdir):
-    platform = Platform('aarch64', 'ubuntu', 'eloquent')
+    platform = Platform('aarch64', 'ubuntu', DEFAULT_TEST_DISTRO)
     tmp = Path(str(tmpdir))
     this_dir = Path(__file__).parent
     out_dir = prepare_docker_build_environment(
@@ -86,7 +87,7 @@ def test_basic_sysroot_creation(tmpdir):
 
     mock_docker_client = Mock()
     mock_data_collector = Mock()
-    platform = Platform('aarch64', 'ubuntu', 'eloquent')
+    platform = Platform('aarch64', 'ubuntu', DEFAULT_TEST_DISTRO)
 
     stage = CreateSysrootStage()
     stage(

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -20,6 +20,9 @@ import pytest
 from ros_cross_compile.pipeline_stages import PipelineStageOptions
 
 
+DEFAULT_TEST_DISTRO = 'foxy'
+
+
 def uses_docker(func):
     """Decorate test to be skipped on platforms that don't have Docker for testing."""
     NO_MAC_REASON = 'CI environment cannot install Docker on Mac OS hosts.'


### PR DESCRIPTION
Fixes build and notifies user of use of EOL distro. 
Eloquent apt repos are not fully available anymore as of the last week.