### PR TITLE
Allow users to get rosdeps for eol distro

### DIFF
--- a/ros_cross_compile/docker/gather_rosdeps.sh
+++ b/ros_cross_compile/docker/gather_rosdeps.sh
@@ -16,7 +16,9 @@ fi
 out_dir=$(dirname "${OUT_PATH}")
 mkdir -p "${out_dir}"
 
-rosdep update
+# Note: users are allowed to build against EOL distros! There are just no updates to them,
+# but they should continue working
+rosdep update --include-eol-distros
 
 cat > "${OUT_PATH}" <<EOF
 #!/bin/bash


### PR DESCRIPTION
Users should be able to get rosdeps for an EOL distro - the packages are still there.