### PR TITLE
cancel installs input prompts

### DIFF
--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -89,7 +89,7 @@ RUN chmod +x ./user-custom-setup && \
 # Use generated rosdep installation script
 COPY install_rosdeps.sh .
 RUN chmod +x install_rosdeps.sh
-RUN apt-get update && \
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     ./install_rosdeps.sh && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes #281 as requested here: https://github.com/ros-tooling/cross_compile/issues/281#issuecomment-751855047

This fix sets DEBIAN_FRONTEND env variable to noninteractive and thus cancels the installations prompts issued by some packages during rosdep-triggered installations.