### PR TITLE
Remove blind except (caught by flake8-blind-except 0.2)

### DIFF
--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -243,8 +243,4 @@ if __name__ == '__main__':
     if sys.version_info < (3, 5):
         logger.warning('You are using an unsupported version of Python.'
                        'Cross-compile only supports Python >= 3.5 per the ROS2 REP 2000.')
-    try:
-        main()
-    except Exception as e:
-        logger.exception(e)
-        exit(1)
+    main()


### PR DESCRIPTION
New release caused build to start failing https://pypi.org/project/flake8-blind-except/0.2.0/

I might have pinned back the dependency instead, but it's not a bad catch, so I'd rather just fix the linter complaint