### PR TITLE
sysroot.Dockerfile: fix GPG keys import given latest ROS GPG Key expiration incident

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         target_arch: [aarch64, armhf, x86_64]
         target_os: [ubuntu, debian]
-        rosdistro: [dashing, eloquent, foxy, galactic, rolling, melodic]
+        rosdistro: [dashing, foxy, galactic, rolling, melodic]
     env:
       METRICS_OUT_DIR: /tmp/collected_metrics
     steps:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool supports compiling a workspace for all combinations of the following:
 * Architecture: `armhf`, `aarch64`, `x86_64`
 * ROS Distro
   * ROS: `kinetic`, `melodic`
-  * ROS 2: `dashing`, `eloquent`, `foxy`, `galactic`, `rolling`
+  * ROS 2: `dashing`, `foxy`, `galactic`, `rolling`
 * OS: `Ubuntu`, `Debian`
 
 NOTE: ROS 2 supports Debian only as a Tier 3 platform.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This tool supports compiling a workspace for all combinations of the following:
 
 * Architecture: `armhf`, `aarch64`, `x86_64`
 * ROS Distro
-  * ROS: `kinetic`, `melodic`
+  * ROS: `melodic`
   * ROS 2: `dashing`, `foxy`, `galactic`, `rolling`
 * OS: `Ubuntu`, `Debian`
 

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -29,15 +29,21 @@ ENV LC_ALL C.UTF-8
 
 # Add the ros apt repo
 RUN apt-get update && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        curl \
         dirmngr \
         gnupg2 \
         lsb-release \
     && rm -rf /var/lib/apt/lists/*
-RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' \
-    --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-
-RUN echo "deb http://packages.ros.org/${ROS_VERSION}/ubuntu `lsb_release -cs` main" \
-    > /etc/apt/sources.list.d/${ROS_VERSION}-latest.list
+RUN if [[ "${ROS_VERSION}" == "ros2" ]]; then \
+      curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg; \
+      echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/${ROS_VERSION}/ubuntu `lsb_release -cs` main" | \
+          tee /etc/apt/sources.list.d/ros2.list > /dev/null; \
+    else \
+      curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add - ; \
+      echo "deb http://packages.ros.org/${ROS_VERSION}/ubuntu `lsb_release -cs` main" \
+          > /etc/apt/sources.list.d/${ROS_VERSION}-latest.list; \
+    fi
 
 # ROS dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -26,7 +26,7 @@ ARCHITECTURE_NAME_MAP = {
 }
 SUPPORTED_ARCHITECTURES = tuple(ARCHITECTURE_NAME_MAP.keys())
 
-SUPPORTED_ROS2_DISTROS = ('dashing', 'eloquent', 'foxy', 'galactic', 'rolling')
+SUPPORTED_ROS2_DISTROS = ('dashing', 'foxy', 'galactic', 'rolling')
 SUPPORTED_ROS_DISTROS = ('kinetic', 'melodic')
 
 ROSDISTRO_OS_MAP = {
@@ -41,10 +41,6 @@ ROSDISTRO_OS_MAP = {
     'dashing': {
         'ubuntu': 'bionic',
         'debian': 'stretch',
-    },
-    'eloquent': {
-        'ubuntu': 'bionic',
-        'debian': 'buster',
     },
     'foxy': {
         'ubuntu': 'focal',

--- a/ros_cross_compile/platform.py
+++ b/ros_cross_compile/platform.py
@@ -27,13 +27,9 @@ ARCHITECTURE_NAME_MAP = {
 SUPPORTED_ARCHITECTURES = tuple(ARCHITECTURE_NAME_MAP.keys())
 
 SUPPORTED_ROS2_DISTROS = ('dashing', 'foxy', 'galactic', 'rolling')
-SUPPORTED_ROS_DISTROS = ('kinetic', 'melodic')
+SUPPORTED_ROS_DISTROS = ('melodic',)
 
 ROSDISTRO_OS_MAP = {
-    'kinetic': {
-        'ubuntu': 'xenial',
-        'debian': 'jessie',
-    },
     'melodic': {
         'ubuntu': 'bionic',
         'debian': 'stretch',

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -60,7 +60,7 @@ cleanup(){
 }
 
 setup(){
-  if [[ "$distro" =~ ^(kinetic|melodic|noetic)$ ]]; then
+  if [[ "$distro" =~ ^(melodic|noetic)$ ]]; then
     ros_version=ros
   else
     ros_version=ros2

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -41,7 +41,7 @@ def test_emulated_docker_build():
     # Very simple smoke test to validate that all internal syntax is correct
     mock_docker_client = Mock()
     mock_data_collector = Mock()
-    platform = Platform('aarch64', 'ubuntu', 'eloquent')
+    platform = Platform('aarch64', 'ubuntu', 'foxy')
 
     stage = EmulatedDockerBuildStage()
     stage(

--- a/test/test_platform.py
+++ b/test/test_platform.py
@@ -49,7 +49,7 @@ def test_platform_argument_validation():
 
 
 def test_construct_x86():
-    p = Platform('x86_64', 'ubuntu', 'eloquent')
+    p = Platform('x86_64', 'ubuntu', 'foxy')
     assert p
 
 
@@ -70,22 +70,18 @@ def verify_base_docker_images(arch, os_name, rosdistro, image_name):
 def test_get_docker_base_image():
     """Test that the correct base docker image is used for all arguments."""
     verify_base_docker_images('aarch64', 'ubuntu', 'dashing', 'arm64v8/ubuntu:bionic')
-    verify_base_docker_images('aarch64', 'ubuntu', 'eloquent', 'arm64v8/ubuntu:bionic')
     verify_base_docker_images('aarch64', 'ubuntu', 'kinetic', 'arm64v8/ubuntu:xenial')
     verify_base_docker_images('aarch64', 'ubuntu', 'melodic', 'arm64v8/ubuntu:bionic')
 
     verify_base_docker_images('aarch64', 'debian', 'dashing', 'arm64v8/debian:stretch')
-    verify_base_docker_images('aarch64', 'debian', 'eloquent', 'arm64v8/debian:buster')
     verify_base_docker_images('aarch64', 'debian', 'kinetic', 'arm64v8/debian:jessie')
     verify_base_docker_images('aarch64', 'debian', 'melodic', 'arm64v8/debian:stretch')
 
     verify_base_docker_images('armhf', 'ubuntu', 'dashing', 'arm32v7/ubuntu:bionic')
-    verify_base_docker_images('armhf', 'ubuntu', 'eloquent', 'arm32v7/ubuntu:bionic')
     verify_base_docker_images('armhf', 'ubuntu', 'kinetic', 'arm32v7/ubuntu:xenial')
     verify_base_docker_images('armhf', 'ubuntu', 'melodic', 'arm32v7/ubuntu:bionic')
 
     verify_base_docker_images('armhf', 'debian', 'dashing', 'arm32v7/debian:stretch')
-    verify_base_docker_images('armhf', 'debian', 'eloquent', 'arm32v7/debian:buster')
     verify_base_docker_images('armhf', 'debian', 'kinetic', 'arm32v7/debian:jessie')
     verify_base_docker_images('armhf', 'debian', 'melodic', 'arm32v7/debian:stretch')
 

--- a/test/test_platform.py
+++ b/test/test_platform.py
@@ -70,19 +70,15 @@ def verify_base_docker_images(arch, os_name, rosdistro, image_name):
 def test_get_docker_base_image():
     """Test that the correct base docker image is used for all arguments."""
     verify_base_docker_images('aarch64', 'ubuntu', 'dashing', 'arm64v8/ubuntu:bionic')
-    verify_base_docker_images('aarch64', 'ubuntu', 'kinetic', 'arm64v8/ubuntu:xenial')
     verify_base_docker_images('aarch64', 'ubuntu', 'melodic', 'arm64v8/ubuntu:bionic')
 
     verify_base_docker_images('aarch64', 'debian', 'dashing', 'arm64v8/debian:stretch')
-    verify_base_docker_images('aarch64', 'debian', 'kinetic', 'arm64v8/debian:jessie')
     verify_base_docker_images('aarch64', 'debian', 'melodic', 'arm64v8/debian:stretch')
 
     verify_base_docker_images('armhf', 'ubuntu', 'dashing', 'arm32v7/ubuntu:bionic')
-    verify_base_docker_images('armhf', 'ubuntu', 'kinetic', 'arm32v7/ubuntu:xenial')
     verify_base_docker_images('armhf', 'ubuntu', 'melodic', 'arm32v7/ubuntu:bionic')
 
     verify_base_docker_images('armhf', 'debian', 'dashing', 'arm32v7/debian:stretch')
-    verify_base_docker_images('armhf', 'debian', 'kinetic', 'arm32v7/debian:jessie')
     verify_base_docker_images('armhf', 'debian', 'melodic', 'arm32v7/debian:stretch')
 
 
@@ -100,7 +96,7 @@ def test_docker_py_version():
 def test_ros_version_map():
     platform = Platform('aarch64', 'ubuntu', 'dashing')
     assert platform.ros_version == 'ros2'
-    platform = Platform('aarch64', 'ubuntu', 'kinetic')
+    platform = Platform('aarch64', 'ubuntu', 'melodic')
     assert platform.ros_version == 'ros'
 
 

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -64,7 +64,7 @@ def test_run_twice(tmpdir):
 
 
 def test_prepare_docker_build_with_user_custom(tmpdir):
-    platform = Platform('aarch64', 'ubuntu', 'eloquent')
+    platform = Platform('aarch64', 'ubuntu', 'foxy')
     tmp = Path(str(tmpdir))
     this_dir = Path(__file__).parent
     out_dir = prepare_docker_build_environment(
@@ -86,7 +86,7 @@ def test_basic_sysroot_creation(tmpdir):
 
     mock_docker_client = Mock()
     mock_data_collector = Mock()
-    platform = Platform('aarch64', 'ubuntu', 'eloquent')
+    platform = Platform('aarch64', 'ubuntu', 'foxy')
 
     stage = CreateSysrootStage()
     stage(

--- a/test/test_sysroot_creator.py
+++ b/test/test_sysroot_creator.py
@@ -45,7 +45,7 @@ def test_emulator_touch(system_mock, tmpdir):
 
 
 def test_prepare_docker_build_basic(tmpdir):
-    platform = Platform('armhf', 'debian', 'kinetic')
+    platform = Platform('armhf', 'debian', 'melodic')
     tmp = Path(str(tmpdir))
     out_dir = prepare_docker_build_environment(platform, tmp, None, None)
 
@@ -57,7 +57,7 @@ def test_prepare_docker_build_basic(tmpdir):
 
 def test_run_twice(tmpdir):
     # The test is that this doesn't throw an exception for already existing paths
-    platform = Platform('armhf', 'debian', 'kinetic')
+    platform = Platform('armhf', 'debian', 'melodic')
     tmp = Path(str(tmpdir))
     prepare_docker_build_environment(platform, tmp, None, None)
     prepare_docker_build_environment(platform, tmp, None, None)


### PR DESCRIPTION
Following https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669, this fix has to happen, otherwise the tool is unusable.