### PR TITLE
Source /custom-data/setup.bash on sysroot build

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ add-apt-repository ppa:rpi-distro/ppa
 apt-get install -y pigpio
 ```
 
+Additionally, a custom setup script may control the build environment by populating the `/custom-data/setup.bash` file which will be sourced before building.
+
 ### Custom post-build script
 
 You may want to perform arbitrary post-processing on your build outputs, in the event of a sucessful build - use `--custom-post-build-script` for this.

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -14,6 +14,7 @@ set +ux
 # shellcheck source=/dev/null
 source /opt/ros/"${ROS_DISTRO}"/setup.bash
 if [ -f /custom-data/setup.bash ]; then
+    # shellcheck source=/dev/null
     source /custom-data/setup.bash
 fi
 set -ux

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -13,6 +13,9 @@ touch /opt/ros/"${ROS_DISTRO}"/setup.bash
 set +ux
 # shellcheck source=/dev/null
 source /opt/ros/"${ROS_DISTRO}"/setup.bash
+if [ -f /custom-data/setup.bash ]; then
+    source /custom-data/setup.bash
+fi
 set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \
   --build-base build_"${TARGET_ARCH}" \


### PR DESCRIPTION
Just a means to control the build environment. I do not have a strong opinion about how this is achieved (as long as there is a way). As such, I'm open to completely changing this patch if a more suitable alternative exists. 

Thanks for the tool BTW !