### PR TITLE
build_workspace: increase verbosity of the colcon build command

### DIFF
--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -20,7 +20,8 @@ fi
 set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \
   --build-base build_"${TARGET_ARCH}" \
-  --install-base install_"${TARGET_ARCH}"
+  --install-base install_"${TARGET_ARCH}" \
+  --event-handlers console_cohesion+ console_package_list+
 
 # Runs user-provided post-build logic (file is present and empty if it wasn't specified)
 /user-custom-post-build


### PR DESCRIPTION
I see it as useful, specially for longer builds where we want to capture the output.