### PR TITLE
Fix mypy by adding types-pkg_resources, and removing Python3.5 support

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -28,7 +28,7 @@ jobs:
         # NOTE: doing a python version matrix on top of the
         # already huge target matrix would take forever,
         # so here we just target the minimum supported version
-        python-version: 3.5
+        python-version: 3.6
     - name: Install dependencies
       run: |
         sudo apt update && sudo apt install -y qemu-user-static

--- a/.github/workflows/pip_e2e_test.yml
+++ b/.github/workflows/pip_e2e_test.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v2.2.2
       with:
-        python-version: 3.5
+        python-version: 3.6
     - name: Install dependencies
       run: |
         sudo apt update && sudo apt install -y qemu-user-static

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note that many others likely work, but these are being thoroughly tested.
 This tool requires that you have already installed
 * [Docker](https://docs.docker.com/install/)
   * Follow the instructions to add yourself to the `docker` group as well, so you can run containers as a non-root user
-* Python 3.5 or higher
+* Python 3.6 or higher
 
 If you are using a Linux host, you must also install QEmu (Docker for OSX performs emulation automatically):
 

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -240,7 +240,7 @@ def main():
 
 
 if __name__ == '__main__':
-    if sys.version_info < (3, 5):
+    if sys.version_info < (3, 6):
         logger.warning('You are using an unsupported version of Python.'
-                       'Cross-compile only supports Python >= 3.5 per the ROS2 REP 2000.')
+                       'Cross-compile only supports Python >= 3.6 per the ROS2 REP 2000.')
     main()

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -61,5 +60,5 @@ setup(
             'ros_cross_compile = ros_cross_compile.ros_cross_compile:main'
         ]
     },
-    python_requires='>=3.5',
+    python_requires='>=3.6',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
     pytest-cov
     pytest-repeat
     pytest-runner
+    types-pkg_resources
     yamllint
 commands =
     pytest --basetemp="{envtmpdir}" --cov=ros_cross_compile --cov-report=xml test/ {posargs}


### PR DESCRIPTION
Python3.5 was deprecated and reached EOL in 2020. The original reason to support this was for Dashing users, which supported 3.5. However, Dashing has also reached EOL. Moving forward we should not bother supporting a deprecated Python version.

`types-pkg_resources` fixes the Python3.6+ builds. Not sure exactly what happened to make this necessary, but it's a simple enough fix.