### PR TITLE
Replaced EOL dashing with foxy in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The command's first argument is the path to your ROS workspace.
 Here is a simple invocation for a standard workflow.
 
 ```bash
-ros_cross_compile /path/to/my/workspace --arch aarch64 --os ubuntu --rosdistro dashing
+ros_cross_compile /path/to/my/workspace --arch aarch64 --os ubuntu --rosdistro foxy
 ```
 
 For information on all available options, run `ros_cross_compile -h`.


### PR DESCRIPTION
The simple example in the [Usage Section](https://github.com/ros-tooling/cross_compile#usage) of the readme no longer succeeds due to rosdep errors (dashing reached its EOL, making it a non-trivial example).

I've changed the targeted rosdistro for the example to `foxy`.
