### PR TITLE
Update colcon defaults usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ build:
   merge-install: true
 ```
 
+Other configurations can be passed and used as command line args. Examples are CMake build arguments, like the build type or the verb configurations for the event handlers:
+
+```yaml
+# my_workspace/defaults.yaml
+build:
+  cmake-args: ["-DCMAKE_BUILD_TYPE=Release"]
+  event-handlers: ["console_direct+"]
+```
+
 ### Custom rosdep script
 
 Your ROS application may need nonstandard rosdep rules.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To build, it runs `colcon build`.
 
 You can provide arbitrary arguments to these commands via the [colcon `defaults.yaml`](https://colcon.readthedocs.io/en/released/user/configuration.html#defaults-yaml).
 
-You can either specify the name of this file via `ros_cross_compile --colcon-defaults relative/path/to/defaults.yaml`, or if not specified, a file called `defaults.yaml` will be used if present.
+You can either specify the name of this file via `ros_cross_compile --colcon-defaults /path/to/defaults.yaml`, or if not specified, a file called `defaults.yaml` will be used if present.
 
 For example, there are repositories checked out in your workspace that contain packages that are not needed for your application - some repos provide many packages and you may only want one!
 In this scenario there is a "bringup" package that acts as the entry point to your application:

--- a/ros_cross_compile/dependencies.py
+++ b/ros_cross_compile/dependencies.py
@@ -82,6 +82,7 @@ def gather_rosdeps(
             'OWNER_USER': str(os.getuid()),
             'ROSDISTRO': platform.ros_distro,
             'SKIP_ROSDEP_KEYS': ' '.join(skip_rosdep_keys),
+            'COLCON_DEFAULTS_FILE': 'defaults.yaml',
             'TARGET_OS': '{}:{}'.format(platform.os_name, platform.os_distro),
         },
         volumes=volumes,

--- a/ros_cross_compile/docker/build_workspace.sh
+++ b/ros_cross_compile/docker/build_workspace.sh
@@ -20,8 +20,7 @@ fi
 set -ux
 colcon build --mixin "${TARGET_ARCH}"-docker \
   --build-base build_"${TARGET_ARCH}" \
-  --install-base install_"${TARGET_ARCH}" \
-  --event-handlers console_cohesion+ console_package_list+
+  --install-base install_"${TARGET_ARCH}"
 
 # Runs user-provided post-build logic (file is present and empty if it wasn't specified)
 /user-custom-post-build

--- a/ros_cross_compile/docker/sysroot.Dockerfile
+++ b/ros_cross_compile/docker/sysroot.Dockerfile
@@ -99,6 +99,10 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     ./install_rosdeps.sh && \
     rm -rf /var/lib/apt/lists/*
 
+# Copy colcon defaults config and set COLCON_DEFAULTS_FILE
+COPY defaults.yaml /root
+ENV COLCON_DEFAULTS_FILE=/root/defaults.yaml
+
 # Set up build tools for the workspace
 COPY mixins/ mixins/
 RUN colcon mixin add cc_mixin file://$(pwd)/mixins/index.yaml && colcon mixin update cc_mixin

--- a/ros_cross_compile/docker_client.py
+++ b/ros_cross_compile/docker_client.py
@@ -23,8 +23,6 @@ from docker.utils import kwargs_from_env as docker_kwargs_from_env
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('Docker Client')
 
-DEFAULT_COLCON_DEFAULTS_FILE = 'defaults.yaml'
-
 
 class DockerClient:
     """Simplified Docker API for this package's usage patterns."""
@@ -32,8 +30,7 @@ class DockerClient:
     def __init__(
         self,
         disable_cache: bool = False,
-        default_docker_dir: Optional[Path] = None,
-        colcon_defaults_file: Optional[Path] = None,
+        default_docker_dir: Optional[Path] = None
     ):
         """
         Construct the DockerClient.
@@ -43,7 +40,6 @@ class DockerClient:
         self._client = docker.from_env()
         self._disable_cache = disable_cache
         self._default_docker_dir = str(default_docker_dir or Path(__file__).parent / 'docker')
-        self._colcon_defaults_file = str(colcon_defaults_file or DEFAULT_COLCON_DEFAULTS_FILE)
 
     def build_image(
         self,
@@ -115,7 +111,6 @@ class DockerClient:
             }
             for src, dest in volumes.items()
         }
-        environment['COLCON_DEFAULTS_FILE'] = self._colcon_defaults_file
         # Note that the `run` kwarg `stream` is not available
         # in the version of dockerpy that we are using, so we must detach to live-stream logs
         # Do not `remove` so that the container can be queried for its exit code after finishing

--- a/ros_cross_compile/ros_cross_compile.py
+++ b/ros_cross_compile/ros_cross_compile.py
@@ -28,7 +28,6 @@ from ros_cross_compile.builders import EmulatedDockerBuildStage
 from ros_cross_compile.data_collector import DataCollector
 from ros_cross_compile.data_collector import DataWriter
 from ros_cross_compile.dependencies import CollectDependencyListStage
-from ros_cross_compile.docker_client import DEFAULT_COLCON_DEFAULTS_FILE
 from ros_cross_compile.docker_client import DockerClient
 from ros_cross_compile.pipeline_stages import PipelineStageOptions
 from ros_cross_compile.platform import Platform
@@ -142,9 +141,9 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         '--colcon-defaults',
         required=False,
-        default=DEFAULT_COLCON_DEFAULTS_FILE,
+        default=None,
         type=str,
-        help='Relative path within the workspace to a file that provides colcon arguments. '
+        help='Provide a path to a configuration file that provides colcon arguments. '
              'See "Package Selection and Build Customization" in README.md for more details.')
     parser.add_argument(
         '--skip-rosdep-keys',
@@ -193,17 +192,18 @@ def cross_compile_pipeline(
     custom_rosdep_script = _path_if(args.custom_rosdep_script)
     custom_setup_script = _path_if(args.custom_setup_script)
     custom_post_build_script = _path_if(args.custom_post_build_script)
+    colcon_defaults_file = _path_if(args.colcon_defaults)
 
     sysroot_build_context = prepare_docker_build_environment(
         platform=platform,
         ros_workspace=ros_workspace_dir,
         custom_setup_script=custom_setup_script,
         custom_post_build_script=custom_post_build_script,
+        colcon_defaults_file=colcon_defaults_file,
         custom_data_dir=custom_data_dir)
     docker_client = DockerClient(
         args.sysroot_nocache,
-        default_docker_dir=sysroot_build_context,
-        colcon_defaults_file=args.colcon_defaults)
+        default_docker_dir=sysroot_build_context)
 
     options = PipelineStageOptions(
         skip_rosdep_keys,

--- a/ros_cross_compile/sysroot_creator.py
+++ b/ros_cross_compile/sysroot_creator.py
@@ -84,6 +84,7 @@ def prepare_docker_build_environment(
     ros_workspace: Path,
     custom_setup_script: Optional[Path] = None,
     custom_post_build_script: Optional[Path] = None,
+    colcon_defaults_file: Optional[Path] = None,
     custom_data_dir: Optional[Path] = None,
 ) -> Path:
     """
@@ -92,6 +93,7 @@ def prepare_docker_build_environment(
     :param platform Information about the target platform
     :param ros_workspace Location of the ROS source workspace
     :param custom_setup_script Optional arbitrary script
+    :param colcon_defaults_file Optional colcon configuration file
     :param custom_data_dir Optional arbitrary directory for use by custom_setup_script
     :return The directory that was created.
     """
@@ -110,6 +112,14 @@ def prepare_docker_build_environment(
 
     _copy_or_touch(custom_setup_script, docker_build_dir / 'user-custom-setup')
     _copy_or_touch(custom_post_build_script, docker_build_dir / 'user-custom-post-build')
+
+    if colcon_defaults_file:
+        _copyfile(colcon_defaults_file, docker_build_dir / 'defaults.yaml')
+    else:
+        (docker_build_dir / 'defaults.yaml').write_text("""
+build:
+  event-handlers: ["console_cohesion+","console_package_list+"]
+""")
 
     setup_emulator(platform.qemu_arch, docker_build_dir)
 

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -185,10 +185,12 @@ list:
   packages-select: [dummy_pkg]
 build:
   packages-select: [dummy_pkg]
+  event-handlers: ["console_cohesion+","console_package_list+"]
 EOF
 
 python3 -m ros_cross_compile "$test_sysroot_dir" \
   --arch "$arch" --os "$os" --rosdistro "$distro" \
+  --colcon-defaults "$test_sysroot_dir/defaults.yaml" \
   --custom-metric-file "${arch}_${os}_${distro}_b"
 CC_SCRIPT_STATUS=$?
 if [[ "$CC_SCRIPT_STATUS" -ne 0 ]]; then

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -158,7 +158,7 @@ def test_colcon_defaults(tmpdir):
     platform = Platform(arch='aarch64', os_name='ubuntu', ros_distro='dashing')
     out_script = ws / rosdep_install_script(platform)
 
-    # no defaults file should get everything
+    # none or default config should get everything
     gather_rosdeps(client, platform, workspace=ws)
 
     result = out_script.read_text()


### PR DESCRIPTION
The functionality to set the `defaults.yaml` file to use wasn't functioning as it was marked, and one needed to add `/ros_ws` prefix to the path so we were actually able to get and use the file. In the other hand, this was limiting us to the workspace files we could pass as colcon defaults.

This PR basically now allow us to pass any file to be used as `default.yaml`. The default behavior of setting `defaults.yaml`, even if it was empty, was kept. Also, I removed the enforcement of the event handlers, and the verbs can now be configured through the colcon `defaults.yaml` file that is passed. I added an example of how this can be done to the README.

@emersonknapp looking forward for your review and feedback. This works quite nicely now on my end and I am able to set any config file without being restricted to the files in my workspace. And the fact that we don't enforce the event handlers is actually good because then I can use any that I want.