### PR TITLE
Trying to fix shell checker by switching to the reviewdog version of it

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,8 +6,8 @@ on:
       - master
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v1
       - name: Run Shellcheck on shell scripts
-        uses: zbeekman/ShellCheck-Linter-Action@v1.0.1
+        uses: reviewdog/action-shellcheck@v1


### PR DESCRIPTION
Trying to fix shell checker by switching to the `reviewdog` version of it
Previous version `zbeekman/ShellCheck-Linter-Action@v1.0.1` became deprecated 

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>