### PR TITLE
Add notice about repository deprecation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Notice: This repository is deprecated. It is outdated and will not be supported anymore.
-Recommended to use native cross-compilation which is up to 8 times faster.
-See details in ROS Discourse discussion
-https://discourse.ros.org/t/call-for-help-maintainership-of-the-ros-cross-compile-tool/26511 
+It is recommended to use a native cross-compilation method, which can be up to 8 times faster.
+See details in this ROS Discourse discussion:
+https://discourse.ros.org/t/call-for-help-maintainership-of-the-ros-cross-compile-tool/26511
 
 # ROS / ROS 2 Cross Compile Tool
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Notice: This repository is deprecated. It is outdated and has lack of support.
+Recommended to use native cross-compilation which is up to 8 times faster.
+See details in ROS Discourse discussion
+https://discourse.ros.org/t/call-for-help-maintainership-of-the-ros-cross-compile-tool/26511 
+
 # ROS / ROS 2 Cross Compile Tool
 
 ![License](https://img.shields.io/github/license/ros-tooling/cross_compile)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Notice: This repository is deprecated. It is outdated and has lack of support.
+## Notice: This repository is deprecated. It is outdated and will not be supported anymore.
 Recommended to use native cross-compilation which is up to 8 times faster.
 See details in ROS Discourse discussion
 https://discourse.ros.org/t/call-for-help-maintainership-of-the-ros-cross-compile-tool/26511 


### PR DESCRIPTION
We are going to deprecate and archive `cross_compile` repo and rational for that is following:
1. There are no volunteers to support it and I don't have enough knowledge and time to support it as well.
1. We have made a post on Discourse about it in July https://discourse.ros.org/t/call-for-help-maintainership-of-the-ros-cross-compile-tool/26511
1. Community mostly expressed opinion that it's outdated and inefficient. It was recommended to use the native cross-compilation instead of QUEMU

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>