### PR TITLE
Disable dependabot and running tests on schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "16:00"
-  open-pull-requests-limit: 1

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -3,10 +3,6 @@ on:
   pull_request:
     # Running on pull requests to catch breaking changes as early as possible.
     # Waiting for this test to pass is recommended, but contributors can use their discretion whether they want to or not.
-  schedule:
-    # Run every morning Pacific Time. Random hour and minute to avoid creating excess traffic during popular times.
-    # Because the test takes a long time (> 30 min) to run, it is configured to run only once a day.
-    - cron:  '17 17 * * *'
 
 jobs:
   build_and_test_20_04:

--- a/.github/workflows/pip_e2e_test.yml
+++ b/.github/workflows/pip_e2e_test.yml
@@ -1,10 +1,8 @@
 name: End-to-end testing for ros-cross-compile using PIP (Nightly Canary)
 on:
-  schedule:
-    # Run every morning Pacific Time.
-    # Random hour and minute to avoid creating excess traffic during popular times.
-    # Because the test takes a long time (> 30 min) to run, it is configured to run only once a day.
-    - cron:  '17 23 * * *'
+  pull_request:
+    # Running on pull requests to catch breaking changes as early as possible.
+    # Waiting for this test to pass is recommended, but contributors can use their discretion whether they want to or not.
 
 jobs:
   build_and_test_20_04:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    # Run every day. This helps detect flakiness,
-    # and broken external dependencies.
-    - cron:  '0 0 * * *'
 
 jobs:
   test_macOS:


### PR DESCRIPTION
Disable dependabot and running tests on schedule before we will archive `cross_compile` repo and make it read only.

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>